### PR TITLE
disableCSSOMInjection in payment page components

### DIFF
--- a/src/components/common/Arrow/index.tsx
+++ b/src/components/common/Arrow/index.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import { StyledSvg } from './components/StyledSvg';
 import { TArrowPalette } from './palette';
 import { useComponentPalette } from '../../../palette';
+import { disableCSSOM } from '../../../helpers/disableCSSOM';
 
 export type TProps = {
     isOpen: boolean;
@@ -11,13 +12,7 @@ export type TProps = {
     palette?: Partial<TArrowPalette>;
 };
 
-export const Arrow: FC<TProps> = ({
-    isOpen,
-    innerSize = 10,
-    outterSize = 24,
-    defaultRotate = 0,
-    palette,
-}) => {
+const ArrowInner: FC<TProps> = ({ isOpen, innerSize = 10, outterSize = 24, defaultRotate = 0, palette }) => {
     const mergedPalette = useComponentPalette('arrow', palette);
 
     return (
@@ -31,3 +26,5 @@ export const Arrow: FC<TProps> = ({
         />
     );
 };
+
+export const Arrow = disableCSSOM(ArrowInner);

--- a/src/components/common/Divider/index.tsx
+++ b/src/components/common/Divider/index.tsx
@@ -2,13 +2,16 @@ import React, { FC } from 'react';
 import { useComponentPalette } from '../../../palette';
 import * as S from './styles';
 import { TDividerPalette } from './palette';
+import { disableCSSOM } from '../../../helpers/disableCSSOM';
 
 export type TProps = {
     palette?: Partial<TDividerPalette>;
 };
 
-export const Divider: FC<TProps> = ({ palette }) => {
+const DividerInner: FC<TProps> = ({ palette }) => {
     const mergedPalette = useComponentPalette('divider', palette);
 
     return <S.Divider $palette={mergedPalette} />;
 };
+
+export const Divider = disableCSSOM(DividerInner);

--- a/src/components/common/Dropdown/index.tsx
+++ b/src/components/common/Dropdown/index.tsx
@@ -2,7 +2,7 @@ import React, { FC, ReactNode, TransitionEvent, useCallback, useRef, useState } 
 import * as S from './styles';
 import { useComponentPalette } from '../../../palette';
 import { TDropdownPalette } from './palette';
-import { StyleSheetManager } from 'styled-components';
+import { disableCSSOM } from '../../../helpers/disableCSSOM';
 
 type TPosition = {
     isAbove: boolean;
@@ -20,14 +20,6 @@ export type TProps = {
     width?: string;
     zIndex?: number;
     onCloseTransitionEnd?: () => void;
-};
-
-export const Dropdown: FC<TProps> = ({ children, ...props }) => {
-    return (
-        <StyleSheetManager disableCSSOMInjection>
-            <DropdownInner {...props}>{children}</DropdownInner>
-        </StyleSheetManager>
-    );
 };
 
 const DropdownInner: FC<TProps> = ({
@@ -126,3 +118,5 @@ const DropdownInner: FC<TProps> = ({
         </S.Wrapper>
     );
 };
+
+export const Dropdown = disableCSSOM(DropdownInner);

--- a/src/components/common/Scrollbar/index.tsx
+++ b/src/components/common/Scrollbar/index.tsx
@@ -2,13 +2,14 @@ import React, { FC, ReactNode, useMemo } from 'react';
 import { Scrollbar as LibScrollbar } from 'react-scrollbars-custom';
 import { useComponentPalette } from '../../../palette';
 import { TScrollbarPalette } from './palette';
+import { disableCSSOM } from '../../../helpers/disableCSSOM';
 
 export type TProps = {
     children: ReactNode;
     maxHeight?: number;
 };
 
-export const Scrollbar: FC<TProps> = ({ children, maxHeight = '100%' }) => {
+const ScrollbarInner: FC<TProps> = ({ children, maxHeight = '100%' }) => {
     const palette = useComponentPalette<TScrollbarPalette>('scrollbar');
 
     const props = useMemo(
@@ -63,3 +64,5 @@ export const Scrollbar: FC<TProps> = ({ children, maxHeight = '100%' }) => {
         </LibScrollbar>
     );
 };
+
+export const Scrollbar = disableCSSOM(ScrollbarInner);

--- a/src/components/common/SecondaryButton/index.tsx
+++ b/src/components/common/SecondaryButton/index.tsx
@@ -3,6 +3,7 @@ import * as S from './styles';
 import { InvoiceboxSpinner } from '../InvoiceboxSpinner';
 import { TSecondaryButtonPalette } from './palette';
 import { useComponentPalette } from '../../../palette';
+import { disableCSSOM } from '../../../helpers/disableCSSOM';
 
 type TButtonProps = { element?: 'button' } & ButtonHTMLAttributes<HTMLButtonElement>;
 type TAnchorProps = { element: 'a' } & AnchorHTMLAttributes<HTMLAnchorElement>;
@@ -14,7 +15,7 @@ export type TProps = (TButtonProps | TAnchorProps) & {
     className?: never;
 };
 
-export const SecondaryButton: FC<TProps> = ({
+const SecondaryButtonInner: FC<TProps> = ({
     element = 'button',
     isLoading = false,
     fullWidth = false,
@@ -50,3 +51,5 @@ export const SecondaryButton: FC<TProps> = ({
         </S.Wrapper>
     );
 };
+
+export const SecondaryButton = disableCSSOM(SecondaryButtonInner);

--- a/src/components/form/CountrySelect/index.tsx
+++ b/src/components/form/CountrySelect/index.tsx
@@ -11,6 +11,7 @@ import { Scrollbar } from '../../common/Scrollbar';
 import { TDropdownProps } from '../../../index';
 import { useComponentPalette } from '../../../palette';
 import { TCountrySelectPalette } from './palette';
+import { disableCSSOM } from '../../../helpers/disableCSSOM';
 
 type TOption = {
     value: string;
@@ -32,7 +33,7 @@ type TControlProps<T> = Pick<TSearchInputProps, 'placeholder'> &
 
 export type TProps = TFieldProps & TControlProps<string>;
 
-export const CountrySelect: FC<TProps> = ({
+const CountrySelectInner: FC<TProps> = ({
     value,
     onChange,
     options,
@@ -122,3 +123,5 @@ export const CountrySelect: FC<TProps> = ({
         </S.Wrapper>
     );
 };
+
+export const CountrySelect = disableCSSOM(CountrySelectInner);

--- a/src/components/form/InputLabel/index.tsx
+++ b/src/components/form/InputLabel/index.tsx
@@ -2,6 +2,7 @@ import React, { FC, ReactNode } from 'react';
 import * as S from './styles';
 import { TInputLabelPalette } from './palette';
 import { useComponentPalette } from '../../../palette';
+import { disableCSSOM } from '../../../helpers/disableCSSOM';
 
 export type TProps = {
     disabled?: boolean;
@@ -10,7 +11,7 @@ export type TProps = {
     children: ReactNode;
 };
 
-export const InputLabel: FC<TProps> = ({ disabled = false, label, inFocus = false, children }) => {
+const InputLabelInner: FC<TProps> = ({ disabled = false, label, inFocus = false, children }) => {
     const palette = useComponentPalette<TInputLabelPalette>('inputLabel');
 
     return (
@@ -24,3 +25,5 @@ export const InputLabel: FC<TProps> = ({ disabled = false, label, inFocus = fals
         </S.Wrapper>
     );
 };
+
+export const InputLabel = disableCSSOM(InputLabelInner);

--- a/src/components/form/PhoneInput/index.tsx
+++ b/src/components/form/PhoneInput/index.tsx
@@ -17,6 +17,7 @@ import { useInputFocus } from '../../../hooks/useInputFocus';
 import { InputLabel } from '../InputLabel';
 import { PureInput, TProps as TPureInputProps } from '../PureInput';
 import { CountrySelect, TProps as TCountrySelectProps } from '../CountrySelect';
+import { disableCSSOM } from '../../../helpers/disableCSSOM';
 
 type TFieldProps = Pick<TPureInputProps, 'name' | 'onBlur' | 'onFocus'> & {
     value: string;
@@ -33,7 +34,7 @@ type TControlProps = Pick<TPureInputProps, 'disabled' | 'id'> & {
 
 export type TProps = TControlProps & TFieldProps;
 
-export const PhoneInput: FC<TProps> = ({
+const PhoneInputInner: FC<TProps> = ({
     onBlur,
     name,
     onFocus,
@@ -245,3 +246,5 @@ export const PhoneInput: FC<TProps> = ({
         </InputLabel>
     );
 };
+
+export const PhoneInput = disableCSSOM(PhoneInputInner);

--- a/src/components/form/SearchInput/index.tsx
+++ b/src/components/form/SearchInput/index.tsx
@@ -7,13 +7,14 @@ import { SearchIcon } from './components/SearchIcon';
 import { CrossIcon } from './components/CrossIcon';
 import { useComponentPalette } from '../../../palette';
 import { TSearchInputPalette } from './palette';
+import { disableCSSOM } from '../../../helpers/disableCSSOM';
 
 export type TProps = Pick<PureInputProps, 'placeholder' | 'hasBorder'> & {
     value: string;
     onChange: (value: string) => void;
 };
 
-export const SearchInput: FC<TProps> = ({ onChange, placeholder, hasBorder, value }) => {
+const SearchInputInner: FC<TProps> = ({ onChange, placeholder, hasBorder, value }) => {
     const { inFocus, handleFocus, handleBlur } = useInputFocus();
     const palette = useComponentPalette<TSearchInputPalette>('searchInput');
 
@@ -52,3 +53,5 @@ export const SearchInput: FC<TProps> = ({ onChange, placeholder, hasBorder, valu
         </InputLabel>
     );
 };
+
+export const SearchInput = disableCSSOM(SearchInputInner);

--- a/src/helpers/disableCSSOM.tsx
+++ b/src/helpers/disableCSSOM.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { StyleSheetManager } from 'styled-components';
+
+export const disableCSSOM = <P extends object>(WrappedComponent: React.ComponentType<P>) => {
+    const WithDisableCSSOMComponent: React.FC<P> = (props) => {
+        return (
+            <StyleSheetManager disableCSSOMInjection>
+                <WrappedComponent {...(props as P)} />
+            </StyleSheetManager>
+        );
+    };
+
+    return WithDisableCSSOMComponent;
+};


### PR DESCRIPTION
Важные компоненты для вебвизора на платёжной странице обернул ХОКом с disableCSSOMInjection т.к. вебвизор яндекса не поддерживает CSSOM, с которым работает styled-components на проде.