### PR TITLE
fix(Drawer,CountrySelect): убрать двойное скругление шапки + проброс …

### DIFF
--- a/src/components/common/Drawer/index.tsx
+++ b/src/components/common/Drawer/index.tsx
@@ -137,7 +137,7 @@ export const Drawer: FC<TProps> = ({
                     </S.Title>
                 )}
 
-                <S.ChildrenWrapper $isBorderRadius={!title} $bgColor={palette.bg} $isPadding={isPadding}>
+                <S.ChildrenWrapper $bgColor={palette.bg} $isPadding={isPadding}>
                     {children}
                 </S.ChildrenWrapper>
             </S.Sheet>

--- a/src/components/common/Drawer/styles.ts
+++ b/src/components/common/Drawer/styles.ts
@@ -86,20 +86,12 @@ export const Title = styled.div<{ $bg: string }>`
     padding: 30px;
     position: relative;
     text-align: center;
-    border-radius: 10px 10px 0 0;
 `;
 
 export const ChildrenWrapper = styled.div<{
     $isPadding: boolean;
     $bgColor: string;
-    $isBorderRadius?: boolean;
 }>`
     ${({ $isPadding }) => $isPadding && 'padding: 32px 16px 36px'};
     background-color: ${({ $bgColor }) => $bgColor};
-
-    ${({ $isBorderRadius }) =>
-        $isBorderRadius &&
-        css`
-            border-radius: 10px 10px 0 0;
-        `}
 `;

--- a/src/components/form/CountrySelect/index.tsx
+++ b/src/components/form/CountrySelect/index.tsx
@@ -28,7 +28,16 @@ type TControlProps<T> = Pick<TSearchInputProps, 'placeholder'> &
     Pick<TCountryItemProps<T>, 'selectedLabel'> & {
         options: TOption[];
         disabled?: boolean;
-    } & Pick<TDropdownProps, 'positionVertical' | 'positionLeft' | 'positionRight' | 'minWidth'>;
+    } & Pick<
+            TDropdownProps,
+            | 'positionVertical'
+            | 'positionLeft'
+            | 'positionRight'
+            | 'minWidth'
+            | 'width'
+            | 'isAutoPosition'
+            | 'isTopPosition'
+        >;
 
 export type TProps = TFieldProps & TControlProps<string>;
 


### PR DESCRIPTION
…позиционирования списка

Drawer: верхнее скругление давал только DragHandle (он всегда сверху), а Title и ChildrenWrapper (при !title) дублировали border-radius тем же фоном — под ручкой появлялась лишняя «ступенька»-скругление. Убрал border-radius у Title и ChildrenWrapper (DragHandle остаётся единственным источником скругления верха).

CountrySelect: расширил Pick<TDropdownProps> на width | isAutoPosition | isTopPosition — даёт потребителю управлять шириной и направлением раскрытия списка стран (например, в боттомшите раскрывать вниз на всю ширину). Поведение по умолчанию не меняется: isAutoPosition остаётся true, если потребитель не передал явный override (spread идёт после хардкода).

Версию не трогаю — release.sh бампит сам (npm version prerelease).