### PR TITLE
fix(CountrySelect): список стран на всю ширину (align-items center→st…

### DIFF
--- a/src/components/form/CountrySelect/stlyes.ts
+++ b/src/components/form/CountrySelect/stlyes.ts
@@ -18,7 +18,7 @@ export const HeaderWrapper = styled.button`
 
 export const ListWrapper = styled.div`
     display: flex;
-    align-items: center;
+    align-items: stretch;
     flex-direction: column;
     pointer-events: auto;
 `;


### PR DESCRIPTION
…retch)

ListWrapper — flex-column с align-items: center, из-за чего <Scrollbar> со списком стран сжимался по ширине КОНТЕНТА и центрировался (справа оставался пустой жёлоб со скроллбаром). Поле поиска спасал только явный width:100%. CountryItem уже width:100% + justify-content:space-between, поэтому достаточно растянуть детей контейнера: align-items center → stretch → список на всю ширину, пункты слева (флаг+название слева, код ИНН/УНН справа).