### PR TITLE
fix(useOutsideClick): игнорировать клики по порталу Dropdown

### DIFF
--- a/src/components/common/Dropdown/index.tsx
+++ b/src/components/common/Dropdown/index.tsx
@@ -9,6 +9,7 @@ import React, {
 } from 'react';
 import { createPortal } from 'react-dom';
 import * as S from './styles';
+import { DROPDOWN_PORTAL_ATTR } from '../../../hooks/useOutsideClick';
 import { useComponentPalette } from '../../../palette';
 import { TDropdownPalette } from './palette';
 
@@ -165,6 +166,7 @@ export const Dropdown = forwardRef<HTMLDivElement, TProps>(
                 {layerRect &&
                     createPortal(
                         <S.PositionLayer
+                            {...{ [DROPDOWN_PORTAL_ATTR]: '' }}
                             style={{
                                 top: layerRect.top,
                                 left: layerRect.left,

--- a/src/hooks/useOutsideClick/index.ts
+++ b/src/hooks/useOutsideClick/index.ts
@@ -1,9 +1,16 @@
 import { RefObject, useEffect, useRef } from 'react';
 
+export const DROPDOWN_PORTAL_ATTR = 'data-invoicebox-dropdown';
+
+export const isDropdownPortalClick = (target: EventTarget | null): boolean =>
+    target instanceof Element && target.closest(`[${DROPDOWN_PORTAL_ATTR}]`) !== null;
+
 // extraRefs — узлы, которые физически вне основного ref (например, дропдаун, вынесенный порталом
 // в document.body), но логически ему принадлежат: клик по ним НЕ считается «снаружи». Без этого
 // портал-дропдаун ловил бы клик как outside и схлопывался. По умолчанию пусто — обратная
 // совместимость со старыми вызовами `const ref = useOutsideClick(onClick)`.
+// Клики по порталу Dropdown (см. DROPDOWN_PORTAL_ATTR) игнорируются автоматически — модалки и
+// другие outside-click обработчики не закрываются при выборе пункта списка.
 export const useOutsideClick = (
     onClick: () => void,
     extraRefs: ReadonlyArray<RefObject<HTMLElement>> = [],
@@ -18,6 +25,7 @@ export const useOutsideClick = (
             const isOutside =
                 ref.current &&
                 !ref.current.contains(target) &&
+                !isDropdownPortalClick(target) &&
                 !extraRefsRef.current.some((extra) => extra.current && extra.current.contains(target));
 
             if (isOutside) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ export type { TProps as TTagsInputProps } from './components/form/TagsInput';
 export { TextInput } from './components/form/TextInput';
 export type { TProps as TTextInputProps } from './components/form/TextInput';
 export { Select } from './components/form/Select';
-export type { TProps as TSelectProps } from './components/form/Select';
+export type { TProps as TSelectProps, TOption, TGroup } from './components/form/Select';
 export { Toggle } from './components/form/Toggle';
 export type { TProps as TToggleProps } from './components/form/Toggle';
 export { DateInput } from './components/form/DateInput';
@@ -69,9 +69,10 @@ export {
     AutocompleteDefaultOption,
     OrganizationAutocompleteItem,
 } from './components/form/Autocomplete/index';
+export type { TSizes } from './components/form/constants';
 
 // hooks
-export { useOutsideClick } from './hooks/useOutsideClick';
+export { useOutsideClick, DROPDOWN_PORTAL_ATTR, isDropdownPortalClick } from './hooks/useOutsideClick';
 export { useInputFocus } from './hooks/useInputFocus';
 export { useUnupdatableHandler } from './hooks/useUnupdatableHandler';
 export { useLoadingSubmit } from './hooks/useLoadingSubmit';


### PR DESCRIPTION
Добавлен data-атрибут на портал Dropdown и проверка isDropdownPortalClick, чтобы модалки не закрывались при выборе пункта списка. Экспортированы DROPDOWN_PORTAL_ATTR, isDropdownPortalClick, TOption, TGroup и TSizes.