### PR TITLE
feat(Chip): семантический variant/type API (обратно совместимо)

### DIFF
--- a/src/components/common/Chip/index.stories.tsx
+++ b/src/components/common/Chip/index.stories.tsx
@@ -1,5 +1,6 @@
+import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { TProps, Chip } from '.';
+import { TProps, Chip, TChipVariant, TChipType } from '.';
 
 const meta: Meta<typeof Chip> = {
     title: 'common/Chip',
@@ -9,10 +10,39 @@ const meta: Meta<typeof Chip> = {
 
 export default meta;
 
-export const Default: StoryObj<TProps> = {
+// Старый путь — сырые цвета (обратная совместимость)
+export const RawColors: StoryObj<TProps> = {
     args: {
         label: 'Название',
-        color: 'blue',
-        bgColor: 'red',
+        color: '#FFFFFF',
+        bgColor: '#2BAA5D',
     },
+};
+
+// Новый путь — семантика variant + type
+export const Semantic: StoryObj<TProps> = {
+    args: {
+        label: 'Оплачен',
+        variant: 'primary',
+        type: 'soft',
+    },
+};
+
+const VARIANTS: TChipVariant[] = ['primary', 'error', 'warning', 'info', 'default', 'individual', 'legal'];
+const TYPES: TChipType[] = ['filled', 'soft', 'outlined'];
+
+// Галерея: все семантические варианты × типы
+export const Gallery: StoryObj = {
+    render: () => (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            {TYPES.map((type) => (
+                <div key={type} style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+                    <span style={{ width: 72, color: '#9A9FA3', fontSize: 12 }}>{type}</span>
+                    {VARIANTS.map((variant) => (
+                        <Chip key={variant} label={variant} variant={variant} type={type} />
+                    ))}
+                </div>
+            ))}
+        </div>
+    ),
 };

--- a/src/components/common/Chip/index.tsx
+++ b/src/components/common/Chip/index.tsx
@@ -2,15 +2,60 @@ import React, { FC, ReactNode } from 'react';
 import { TChipSize, Wrapper } from './styles';
 import { Typography } from '../Typography';
 
-export type TProps = {
-    label: string | ReactNode;
-    color: string;
-    bgColor: string;
-    size?: TChipSize;
+export type TChipVariant = 'primary' | 'error' | 'warning' | 'info' | 'default' | 'individual' | 'legal';
+export type TChipType = 'filled' | 'soft' | 'outlined';
+
+// Семантическая палитра (значения по дизайн-токенам; при желании заменить на theme).
+const PALETTE: Record<TChipVariant, { solid: string; soft: string; text: string }> = {
+    primary: { solid: '#2BAA5D', soft: 'rgba(43, 170, 93, 0.12)', text: '#279954' },
+    error: { solid: '#EB5757', soft: 'rgba(235, 87, 87, 0.16)', text: '#D34E4E' },
+    warning: { solid: '#FEBC59', soft: 'rgba(254, 188, 89, 0.16)', text: '#E5A950' },
+    info: { solid: '#6590FD', soft: 'rgba(101, 144, 253, 0.16)', text: '#5B82E4' },
+    default: { solid: '#9A9FA3', soft: 'rgba(53, 63, 71, 0.08)', text: '#72797F' },
+    individual: { solid: '#5119B7', soft: 'rgba(81, 25, 183, 0.16)', text: '#5119B7' },
+    legal: { solid: '#006C9C', soft: 'rgba(0, 108, 156, 0.16)', text: '#006C9C' },
 };
 
-export const Chip: FC<TProps> = ({ label, bgColor, color, size = 'xs' }) => (
-    <Wrapper $color={color} $backgroundColor={bgColor} $size={size}>
-        {typeof label === 'string' ? <Typography variant="smallMedium">{label}</Typography> : label}
-    </Wrapper>
-);
+const resolve = (
+    variant: TChipVariant,
+    type: TChipType,
+): { color: string; bgColor: string; borderColor: string } => {
+    const p = PALETTE[variant];
+    if (type === 'filled') return { color: '#FFFFFF', bgColor: p.solid, borderColor: 'transparent' };
+    if (type === 'soft') return { color: p.text, bgColor: p.soft, borderColor: 'transparent' };
+    return { color: p.text, bgColor: 'transparent', borderColor: p.solid }; // outlined
+};
+
+type TPropsBase = {
+    label: string | ReactNode;
+    size?: TChipSize;
+};
+// Старый путь: сырые цвета (обратная совместимость — существующие вызовы не меняются).
+type TPropsRaw = TPropsBase & {
+    color: string;
+    bgColor: string;
+    variant?: never;
+    type?: never;
+};
+// Новый путь: семантика (variant + type) → цвета раскладываются внутри.
+type TPropsSemantic = TPropsBase & {
+    variant: TChipVariant;
+    type?: TChipType;
+    color?: never;
+    bgColor?: never;
+};
+export type TProps = TPropsRaw | TPropsSemantic;
+
+export const Chip: FC<TProps> = (props) => {
+    const { label, size = 'xs' } = props;
+    const { color, bgColor, borderColor } =
+        'variant' in props && props.variant
+            ? resolve(props.variant, props.type ?? 'filled')
+            : { color: props.color, bgColor: props.bgColor, borderColor: 'transparent' };
+
+    return (
+        <Wrapper $color={color} $backgroundColor={bgColor} $borderColor={borderColor} $size={size}>
+            {typeof label === 'string' ? <Typography variant="labelsHintsBold">{label}</Typography> : label}
+        </Wrapper>
+    );
+};

--- a/src/components/common/Chip/styles.ts
+++ b/src/components/common/Chip/styles.ts
@@ -1,15 +1,17 @@
 import styled from 'styled-components';
 
-export type TChipSize = 'xxs' | 'xs';
+export type TChipSize = 'xxs' | 'xs' | 's';
 
 const CHIP_PADDING_MAP: Record<TChipSize, string> = {
     xxs: '0 4px',
     xs: '4px 6px',
+    s: '9px 16px',
 };
 
 export const Wrapper = styled.div<{
     $color: string;
     $backgroundColor: string;
+    $borderColor?: string;
     $size: TChipSize;
 }>`
     display: inline-flex;
@@ -18,6 +20,7 @@ export const Wrapper = styled.div<{
     padding: ${({ $size }) => CHIP_PADDING_MAP[$size]};
     color: ${({ $color }) => $color};
     background-color: ${({ $backgroundColor }) => $backgroundColor};
+    border: 1.5px solid ${({ $borderColor }) => $borderColor ?? 'transparent'};
     border-radius: 6px;
     white-space: nowrap;
 `;


### PR DESCRIPTION
## Что
Аддитивно расширяет `Chip` семантическим API, не ломая существующее использование.

### Новое (опционально)
- `variant`: `primary | error | warning | info | default | individual | legal`
- `type`: `filled | soft | outlined` (у `outlined` появляется бордер)
- внутренняя `PALETTE` раскладывает `variant`+`type` → `color`/`bgColor`/`borderColor`
- размер `s` в дополнение к `xxs`/`xs`
- строковый `label` рендерится через `Typography variant="labelsHintsBold"` (700) по дизайну (Labels&hints Bold), вместо `smallMedium`

### Обратная совместимость
Старое API `{ label, color, bgColor, size }` работает без изменений — пропсы оформлены как union (raw | semantic), существующие вызовы не трогаются.

### Storybook
`common/Chip`: истории `RawColors`, `Semantic`, `Gallery` (все варианты × типы).

### Вне скоупа
Заметил: Storybook не задаёт `-webkit-font-smoothing`, из-за чего bold-текст на macOS рендерится субпиксельно и выглядит толще, чем в проде/Figma. Это не про Chip — вынесу отдельно, если нужно.
