### PR TITLE
Связка label и input через htmlFor/id для доступности

### DIFF
--- a/src/components/common/Typography/index.tsx
+++ b/src/components/common/Typography/index.tsx
@@ -4,6 +4,7 @@ import React, {
     forwardRef,
     HTMLAttributes,
     InputHTMLAttributes,
+    LabelHTMLAttributes,
     TextareaHTMLAttributes,
 } from 'react';
 import * as S from './styles';
@@ -16,6 +17,7 @@ type THeadingProps = {
     element: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 } & HTMLAttributes<HTMLHeadingElement>;
 type TButtonProps = { element: 'button' } & ButtonHTMLAttributes<HTMLButtonElement>;
+type TLabelProps = { element: 'label' } & LabelHTMLAttributes<HTMLLabelElement>;
 type TInputProps = { element: 'input' } & InputHTMLAttributes<HTMLInputElement>;
 type TTextAreaProps = { element: 'textarea' } & Omit<
     TextareaHTMLAttributes<HTMLTextAreaElement>,
@@ -28,7 +30,16 @@ type TGeneralProps = {
 };
 
 export type TTypographyProps = TGeneralProps &
-    (TDivProps | TParagraphProps | TSpanProps | THeadingProps | TButtonProps | TInputProps | TTextAreaProps);
+    (
+        | TDivProps
+        | TParagraphProps
+        | TSpanProps
+        | THeadingProps
+        | TButtonProps
+        | TLabelProps
+        | TInputProps
+        | TTextAreaProps
+    );
 
 export const Typography: FC<TTypographyProps> = ({ variant, element = 'div', ...rest }) => {
     return <S.Wrapper as={element} $variant={variant} {...rest} />;

--- a/src/components/form/Autocomplete/components/Autocomplete/index.tsx
+++ b/src/components/form/Autocomplete/components/Autocomplete/index.tsx
@@ -116,6 +116,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, TProps>(
         const [activeIndex, setActiveIndex] = useState(-1);
         const baseId = useId();
         const listboxId = `${baseId}-listbox`;
+        const inputId = `${baseId}-input`;
         const activeOptionRef = useRef<HTMLButtonElement | null>(null);
         const palette = useComponentPalette<TAutocompleteDefaultOptionPalette>('autocompleteDefaultOption');
 
@@ -237,6 +238,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, TProps>(
                             ? inputPaddingLeft - LABEL_PADDING
                             : undefined
                     }
+                    htmlFor={inputId}
                 >
                     <S.InputLabelContent>
                         {children ? <S.ChildrenWrapper>{children}</S.ChildrenWrapper> : null}
@@ -252,6 +254,8 @@ export const Autocomplete = forwardRef<HTMLInputElement, TProps>(
                             </ModernPlaceholder>
                         )}
                         <PureInput
+                            id={inputId}
+                            aria-label={label && !inputLabel ? label : undefined}
                             ref={ref}
                             hasError={hasError}
                             inFocus={inFocus}

--- a/src/components/form/CurrencyInput/CoreCurrencyInput/index.tsx
+++ b/src/components/form/CurrencyInput/CoreCurrencyInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useId } from 'react';
 import { InputLabel, TProps as TInputLabelProps } from '../../InputLabel';
 import { useInputFocus } from '../../../../hooks/useInputFocus';
 import { StyledCurrencyInputFromLibrary, InputWrapper } from './styles';
@@ -10,7 +10,7 @@ import { useInputStyles } from '../../_hooks/useInputStyles';
 
 export type TProps = Pick<
     CurrencyInputProps,
-    'allowNegativeValue' | 'onValueChange' | 'value' | 'defaultValue' | 'allowDecimals' | 'onBlur'
+    'allowNegativeValue' | 'onValueChange' | 'value' | 'defaultValue' | 'allowDecimals' | 'onBlur' | 'id'
 > &
     Pick<TInputLabelProps, 'label' | 'disabled'> & {
         hasError?: boolean;
@@ -33,9 +33,13 @@ export const CoreCurrencyInput: FC<TProps> = ({
     required = false,
     onBlur,
     useModernStyles = false,
+    id,
 }) => {
     const { inFocus, handleFocus, handleBlur } = useInputFocus({ onBlur });
     const palette = useComponentPalette<TPureInputPalette>('pureInput');
+
+    const fallbackId = useId();
+    const inputId = id ?? fallbackId;
 
     const { modernPlaceholder, paddingAndVariantOptions, inputLabel, fieldSize } = useInputStyles({
         isHaveValue: !!value || typeof defaultValue === 'number',
@@ -55,10 +59,13 @@ export const CoreCurrencyInput: FC<TProps> = ({
             required={required}
             useModernStyles={useModernStyles}
             size={fieldSize}
+            htmlFor={inputId}
         >
             <InputWrapper>
                 {modernPlaceholder}
                 <StyledCurrencyInputFromLibrary
+                    id={inputId}
+                    aria-label={label && !inputLabel ? label : undefined}
                     $palette={palette}
                     $hasBorder={!useModernStyles || hasError}
                     $paddingLeft={18}

--- a/src/components/form/DateInput/index.tsx
+++ b/src/components/form/DateInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FC, FocusEvent, useCallback, useEffect, useRef, useState } from 'react';
+import React, { ChangeEvent, FC, FocusEvent, useCallback, useEffect, useId, useRef, useState } from 'react';
 import * as S from './styles';
 import { logic } from './logic';
 import { useOutsideClick } from '../../../hooks/useOutsideClick';
@@ -25,7 +25,7 @@ export type TProps = {
     >;
     useModernStyles?: boolean;
     required?: boolean;
-} & Pick<TPureInputProps, 'hasError' | 'name' | 'onBlur' | 'onFocus'> &
+} & Pick<TPureInputProps, 'hasError' | 'name' | 'onBlur' | 'onFocus' | 'id'> &
     Pick<TInputLabelProps, 'label'> &
     Pick<TCalendarProps, 'maxDate' | 'minDate'> & { size?: TSizes };
 
@@ -46,9 +46,13 @@ export const DateInput: FC<TProps> = ({
     placeholder,
     useModernStyles = false,
     required = false,
+    id,
 }) => {
     const palette = useComponentPalette<TDateInputPalette>('dateInput');
     const inputRef = useRef<HTMLInputElement>(null);
+
+    const fallbackId = useId();
+    const inputId = id ?? fallbackId;
     const isMobile = useMobile();
 
     const [isOpen, setOpenFlag] = useState(false);
@@ -132,10 +136,13 @@ export const DateInput: FC<TProps> = ({
                 useModernStyles={useModernStyles}
                 size={fieldSize}
                 required={required}
+                htmlFor={inputId}
             >
                 <S.InputWrapper>
                     {modernPlaceholder}
                     <PureInput
+                        id={inputId}
+                        aria-label={label && !inputLabel ? label : undefined}
                         onClick={handleTrigger}
                         ref={inputRef}
                         hasError={hasError}

--- a/src/components/form/DateTimeInput/index.tsx
+++ b/src/components/form/DateTimeInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FC, FocusEvent, useCallback, useRef, useState } from 'react';
+import React, { ChangeEvent, FC, FocusEvent, useCallback, useId, useRef, useState } from 'react';
 import { useComponentPalette } from '../../../palette';
 import { useOutsideClick } from '../../../hooks/useOutsideClick';
 import { useInputFocus } from '../../../hooks/useInputFocus';
@@ -30,7 +30,7 @@ export type TProps = {
     cancelLabel?: string;
     required?: boolean;
     useModernStyles?: boolean;
-} & Pick<TPureInputProps, 'hasError' | 'name' | 'onBlur' | 'onFocus'> &
+} & Pick<TPureInputProps, 'hasError' | 'name' | 'onBlur' | 'onFocus' | 'id'> &
     Pick<TInputLabelProps, 'label'> &
     Pick<TCalendarProps, 'maxDate' | 'minDate'> & { size?: TSizes };
 
@@ -51,9 +51,13 @@ export const DateTimeInput: FC<TProps> = ({
     cancelLabel,
     required = false,
     useModernStyles = false,
+    id,
 }) => {
     const palette = useComponentPalette<TDateTimeInputPalette>('dateTimeInput');
     const inputRef = useRef<HTMLInputElement>(null);
+
+    const fallbackId = useId();
+    const inputId = id ?? fallbackId;
     const isMobile = useMobile();
     const withTime = true;
 
@@ -182,10 +186,13 @@ export const DateTimeInput: FC<TProps> = ({
                 required={required}
                 useModernStyles={useModernStyles}
                 size={fieldSize}
+                htmlFor={inputId}
             >
                 <S.InputWrapper>
                     {modernPlaceholder}
                     <PureInput
+                        id={inputId}
+                        aria-label={label && !inputLabel ? label : undefined}
                         onClick={handleTrigger}
                         ref={inputRef}
                         hasError={hasError}

--- a/src/components/form/InputLabel/index.tsx
+++ b/src/components/form/InputLabel/index.tsx
@@ -13,6 +13,7 @@ export type TProps = {
     useModernStyles?: boolean;
     size?: TSizes;
     left?: number;
+    htmlFor?: string;
 };
 
 export const InputLabel: FC<TProps> = ({
@@ -24,6 +25,7 @@ export const InputLabel: FC<TProps> = ({
     useModernStyles = false,
     size = 'M',
     left,
+    htmlFor,
 }) => {
     const palette = useComponentPalette<TInputLabelPalette>('inputLabel');
 
@@ -42,6 +44,8 @@ export const InputLabel: FC<TProps> = ({
         >
             {label && (
                 <S.Label
+                    element="label"
+                    htmlFor={htmlFor}
                     $palette={palette}
                     $inFocus={inFocus}
                     variant={

--- a/src/components/form/PhoneInput/index.tsx
+++ b/src/components/form/PhoneInput/index.tsx
@@ -7,6 +7,7 @@ import React, {
     useMemo,
     useState,
     useRef,
+    useId,
 } from 'react';
 import InputMask from '@mona-health/react-input-mask';
 import * as S from './styles';
@@ -65,6 +66,9 @@ export const PhoneInput: FC<TProps> = ({
 }) => {
     const inputRef = useRef<HTMLInputElement>();
     const isMobile = useMobile();
+
+    const fallbackId = useId();
+    const inputId = id ?? fallbackId;
 
     const phoneInputLogic = useMemo(
         () => new PhoneInputLogic(isSupportCityRusPhoneNumber),
@@ -267,6 +271,7 @@ export const PhoneInput: FC<TProps> = ({
             useModernStyles={useModernStyles}
             size={fieldSize}
             left={isHaveSelectCountries && useModernStyles ? 65 : undefined}
+            htmlFor={inputId}
         >
             <S.InputLabelContent>
                 {useModernStyles && (
@@ -311,7 +316,8 @@ export const PhoneInput: FC<TProps> = ({
                     ref={inputRef}
                 >
                     <PureInput
-                        id={id}
+                        id={inputId}
+                        aria-label={label && !inputLabel ? label : undefined}
                         hasError={hasPureInputError}
                         inFocus={inFocus}
                         name={name}

--- a/src/components/form/PositiveIntegerInput/index.tsx
+++ b/src/components/form/PositiveIntegerInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback } from 'react';
+import React, { FC, useCallback, useId } from 'react';
 import * as S from './styles';
 import { useInputFocus } from '../../../hooks/useInputFocus';
 import { InputLabel, TProps as TInputLabelProps } from '../InputLabel';
@@ -19,7 +19,7 @@ export type TProps = {
 } & Pick<TInputLabelProps, 'label'> &
     Pick<
         TPureInputProps,
-        'placeholder' | 'hasError' | 'onFocus' | 'onBlur' | 'disabled' | 'name' | 'useModernStyles'
+        'placeholder' | 'hasError' | 'onFocus' | 'onBlur' | 'disabled' | 'name' | 'useModernStyles' | 'id'
     > & {
         size?: TSizes;
     };
@@ -37,8 +37,12 @@ export const PositiveIntegerInput: FC<TProps> = ({
     name,
     size,
     useModernStyles = false,
+    id,
 }) => {
     const { inFocus, handleFocus, handleBlur } = useInputFocus({ onFocus, onBlur });
+
+    const fallbackId = useId();
+    const inputId = id ?? fallbackId;
 
     const { inputLabel, paddingAndVariantOptions, modernPlaceholder, fieldSize } = useInputStyles({
         isHaveValue: typeof value === 'number',
@@ -72,10 +76,18 @@ export const PositiveIntegerInput: FC<TProps> = ({
     }, [decrement, value, onChange]);
 
     return (
-        <InputLabel inFocus={inFocus} label={inputLabel} useModernStyles={useModernStyles} size={fieldSize}>
+        <InputLabel
+            inFocus={inFocus}
+            label={inputLabel}
+            useModernStyles={useModernStyles}
+            size={fieldSize}
+            htmlFor={inputId}
+        >
             <S.ControlWrapper>
                 {modernPlaceholder}
                 <PureInput
+                    id={inputId}
+                    aria-label={label && !inputLabel ? label : undefined}
                     name={name}
                     hasError={hasError}
                     inFocus={inFocus}

--- a/src/components/form/PureInput/index.tsx
+++ b/src/components/form/PureInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, InputHTMLAttributes, TextareaHTMLAttributes, useCallback } from 'react';
+import React, { ChangeEvent, InputHTMLAttributes, TextareaHTMLAttributes, useCallback, useId } from 'react';
 import * as S from './styles';
 import { useComponentPalette } from '../../../palette';
 import { TPureInputPalette } from './palette';
@@ -41,11 +41,13 @@ export const PureInput = React.forwardRef<HTMLInputElement, TProps>(
             variant = 'bodyMRegular',
             renderedValue,
             useModernStyles = false,
+            id,
             ...rest
         },
         ref,
     ) => {
         const palette = useComponentPalette<TPureInputPalette>('pureInput');
+        const fallbackId = useId();
 
         const handleChange = useCallback(
             (event: ChangeEvent<HTMLInputElement>) => {
@@ -74,6 +76,7 @@ export const PureInput = React.forwardRef<HTMLInputElement, TProps>(
                 $borderRadius={borderRadius}
                 onChange={handleChange}
                 $useModernStyles={useModernStyles}
+                id={id ?? fallbackId}
                 {...rest}
             >
                 {renderedValue}

--- a/src/components/form/SearchInput/index.tsx
+++ b/src/components/form/SearchInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useCallback, forwardRef } from 'react';
+import React, { ChangeEvent, useCallback, forwardRef, useId } from 'react';
 import * as S from './styles';
 import { InputLabel } from '../InputLabel';
 import { PureInput, TProps as PureInputProps } from '../PureInput';
@@ -12,7 +12,15 @@ import { useInputStyles } from '../_hooks/useInputStyles';
 
 export type TProps = Pick<
     PureInputProps,
-    'placeholder' | 'hasBorder' | 'autoFocus' | 'name' | 'onFocus' | 'onBlur' | 'isOnlyNumbers' | 'maxLength'
+    | 'placeholder'
+    | 'hasBorder'
+    | 'autoFocus'
+    | 'name'
+    | 'onFocus'
+    | 'onBlur'
+    | 'isOnlyNumbers'
+    | 'maxLength'
+    | 'id'
 > & {
     value: string;
     onChange: (value: string) => void;
@@ -35,10 +43,14 @@ export const SearchInput = forwardRef<HTMLInputElement, TProps>(
             maxLength,
             size,
             useModernStyles = false,
+            id,
         },
         ref,
     ) => {
         const { inFocus, handleFocus, handleBlur } = useInputFocus({ onFocus, onBlur });
+
+        const fallbackId = useId();
+        const inputId = id ?? fallbackId;
         const palette = useComponentPalette<TSearchInputPalette>('searchInput');
 
         const { inputLabel, paddingAndVariantOptions, modernPlaceholder, fieldSize } = useInputStyles({
@@ -67,10 +79,13 @@ export const SearchInput = forwardRef<HTMLInputElement, TProps>(
                 useModernStyles={useModernStyles}
                 size={fieldSize}
                 label={useModernStyles ? inputLabel : undefined}
+                htmlFor={inputId}
             >
                 {modernPlaceholder}
                 <PureInput
                     ref={ref}
+                    id={inputId}
+                    aria-label={useModernStyles && inputLabel ? undefined : placeholder}
                     paddingRight={56}
                     hasBorder={hasBorder}
                     onChange={handleInputChange}

--- a/src/components/form/Select/components/Input/index.tsx
+++ b/src/components/form/Select/components/Input/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useId } from 'react';
 import * as S from './styles';
 import { InputLabel, TProps as TInputLabelProps } from '../../../InputLabel';
 import { PureInput, TProps as TPureInputProps } from '../../../PureInput';
@@ -8,7 +8,10 @@ import { TSizes } from '../../../constants';
 import { useInputStyles } from '../../../_hooks/useInputStyles';
 
 export type TProps = Pick<TInputLabelProps, 'inFocus' | 'label' | 'required'> &
-    Pick<TPureInputProps, 'hasError' | 'placeholder' | 'name' | 'onFocus' | 'onBlur' | 'value' | 'onClick'> &
+    Pick<
+        TPureInputProps,
+        'hasError' | 'placeholder' | 'name' | 'onFocus' | 'onBlur' | 'value' | 'onClick' | 'id'
+    > &
     Pick<TArrowProps, 'isOpen'> & {
         onReset?: () => void;
         size?: TSizes;
@@ -34,9 +37,13 @@ export const Input = forwardRef<HTMLInputElement, TProps>(
             onClick,
             required,
             useModernStyles = false,
+            id,
         },
         ref,
     ) => {
+        const fallbackId = useId();
+        const inputId = id ?? fallbackId;
+
         const { inputLabel, paddingAndVariantOptions, modernPlaceholder, fieldSize } = useInputStyles({
             isHaveValue: !!value,
             useModernStyles,
@@ -57,10 +64,13 @@ export const Input = forwardRef<HTMLInputElement, TProps>(
                 required={required}
                 useModernStyles={useModernStyles}
                 size={fieldSize}
+                htmlFor={inputId}
             >
                 <S.ControlWrapper>
                     {modernPlaceholder}
                     <PureInput
+                        id={inputId}
+                        aria-label={label && !inputLabel ? label : undefined}
                         ref={ref}
                         hasError={hasError}
                         inFocus={inFocus}

--- a/src/components/form/TagsInput/index.tsx
+++ b/src/components/form/TagsInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FC, useState, KeyboardEvent, useRef, FocusEvent } from 'react';
+import React, { ChangeEvent, FC, useState, KeyboardEvent, useRef, FocusEvent, useId } from 'react';
 import { InputLabel, TProps as TInputLabelProps } from '../InputLabel';
 import { PureInput } from '../PureInput';
 import * as S from './styles';
@@ -32,6 +32,8 @@ export const TagsInput: FC<TProps> = ({
 
     const [inputValue, setInputValue] = useState('');
     const { inFocus, handleFocus, handleBlur } = useInputFocus();
+
+    const inputId = useId();
 
     const inputRef = useRef<HTMLInputElement>(null);
 
@@ -116,7 +118,7 @@ export const TagsInput: FC<TProps> = ({
     };
 
     return (
-        <InputLabel label={label}>
+        <InputLabel label={label} htmlFor={inputId}>
             <S.PureInputStyledWrapper
                 $palette={pureInputPalette}
                 $hasBorder
@@ -157,6 +159,7 @@ export const TagsInput: FC<TProps> = ({
                     ))}
                     <S.InputWithSaveButtonWrapper>
                         <PureInput
+                            id={inputId}
                             ref={inputRef}
                             hasBorder={inFocus}
                             paddingBottom={0}

--- a/src/components/form/TextInput/index.tsx
+++ b/src/components/form/TextInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, ReactNode, useCallback } from 'react';
+import React, { ChangeEvent, ReactNode, useCallback, useId } from 'react';
 import * as S from './styles';
 import { InputLabel, TProps as TInputLabelProps } from '../InputLabel';
 import { PureInput, TProps as TPureInputProps } from '../PureInput';
@@ -71,6 +71,9 @@ export const TextInput = React.forwardRef<HTMLInputElement, TProps>(
     ) => {
         const { inFocus, handleFocus, handleBlur } = useInputFocus({ onFocus, onBlur });
 
+        const fallbackId = useId();
+        const inputId = id ?? fallbackId;
+
         const { ref: childrenRef, width: childrenWidth } = useElementWidth<HTMLDivElement>();
 
         const placeholderPaddingRight = childrenWidth
@@ -103,11 +106,13 @@ export const TextInput = React.forwardRef<HTMLInputElement, TProps>(
                 required={required}
                 size={fieldSize}
                 useModernStyles={useModernStyles}
+                htmlFor={inputId}
             >
                 <S.InputLabelContent>
                     {modernPlaceholder}
                     <PureInput
-                        id={id}
+                        id={inputId}
+                        aria-label={label && !inputLabel ? label : undefined}
                         ref={ref}
                         name={name}
                         disabled={disabled}


### PR DESCRIPTION
InputLabel рендерит настоящий label с htmlFor, Typography поддерживает element='label'. PureInput и все обёртки полей (TextInput, PhoneInput, SearchInput, DateInput, DateTimeInput, PositiveIntegerInput, TagsInput, Select, Autocomplete, CoreCurrencyInput) генерируют id через useId, если проп id не передан. При скрытом лейбле (useModernStyles до фокуса) на input ставится aria-label, чтобы поле всегда имело доступное имя.