### PR TITLE
build: скрипты lint/typecheck/build + конфиг jest (задачи 0.1, 0.2)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,11 @@
         "es2022": true,
         "node": false
     },
+    "settings": {
+        "react": {
+            "version": "detect"
+        }
+    },
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "project": "tsconfig.json"

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    testPathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/node_modules/'],
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "scripts": {
         "storybook": "storybook dev -p 6006",
         "release": "./release.sh",
-        "test": "jest"
+        "test": "jest",
+        "lint": "eslint src --ext .ts,.tsx",
+        "typecheck": "tsc --project tsconfig.json --noEmit --emitDeclarationOnly false",
+        "build": "rm -rf dist && babel src --extensions .ts,.tsx --out-dir dist --copy-files && babel src --extensions .ts,.tsx --out-dir dist/esm --copy-files --config-file ./babel.config.esm.json && tsc --project tsconfig.json"
     },
     "bugs": {
         "url": "https://github.com/InvoiceBox/invoicebox-ui/issues"


### PR DESCRIPTION
## Что сделано

Задачи 0.1 и 0.2 из волны 0 плана рефакторинга (ARCH-001, TEST-002).

- **`npm run lint`** — `eslint src --ext .ts,.tsx`. Конфиг существовал, но его ничто не запускало. Сейчас: 0 ошибок, 6 предупреждений (известные `any`, будут закрыты задачей 3.1).
- **`npm run typecheck`** — `tsc --noEmit` (с `--emitDeclarationOnly false`, иначе конфликт с настройкой tsconfig). Проходит чисто.
- **`npm run build`** — повторяет шаги сборки dist из `release.sh` (CJS + ESM + декларации), чтобы сборку можно было гонять отдельно и позже в CI. `release.sh` не менялся.
- **`jest.config.js`** с `testPathIgnorePatterns` для `dist/` — раньше после локальной сборки `npm test` выполнял один и тот же тест 3 раза (из `src/`, `dist/`, `dist/esm/`). Проверено: с собранным `dist/` теперь 1 test suite.
- В `.eslintrc.json` добавлен `settings.react.version: "detect"` — убирает предупреждение eslint-plugin-react при каждом запуске.

## Проверено локально

- `npm run lint` — 0 ошибок
- `npm run typecheck` — чисто
- `npm run build` — dist/index.js, dist/esm/index.js, dist/index.d.ts на месте
- `npm test` — 1 suite, 2 теста, зелёные (и до, и после сборки dist)

## Замечание

`.eslintrc.json` подключает `plugin:jest/recommended`, но `eslint-plugin-jest` нет в devDependencies — он подтягивается транзитивно через storybook-пресеты. Работает, но хрупко: стоит добавить его явно (предлагаю в задаче 3.6 при апгрейде ESLint или отдельным мелким PR).
