### PR TITLE
ci: GitHub Actions — lint, typecheck, test, build (задача 0.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+    push:
+        branches: [develop, main]
+    pull_request:
+        branches: [develop, main]
+
+jobs:
+    checks:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  # задача 0.4 перенесёт версию в .nvmrc (node-version-file)
+                  node-version: '20.20.1'
+                  cache: npm
+
+            - run: npm ci
+
+            - run: npm run lint
+
+            - run: npm run typecheck
+
+            - run: npm test
+
+            - run: npm run build


### PR DESCRIPTION
## Что сделано

Задача 0.3 из волны 0 (PLAT-001, TEST-004): первый CI для репозитория.

- `.github/workflows/ci.yml` — запускается на push и pull request в `develop`/`main`.
- Порядок стадий по плану аудита: `npm ci` → `lint` → `typecheck` → `test` → `build`. Опирается на скрипты из #270.
- Node 20.20.1, кеш npm через `actions/setup-node`.

## Проверка

Сам этот PR — первый запуск workflow: все пять стадий должны пройти. Ссылку на зелёный run добавлю в комментарий.

## Дальше

- 0.4: `.nvmrc` + `node-version-file` в workflow, чтобы версия Node жила в одном месте.
- После стабилизации CI: сделать джобу required-проверкой для merge в `develop` (настройка branch protection, руками в GitHub).
