### PR TITLE
fix(AppCardLink): rel="noopener noreferrer" (задача 0.6)

### DIFF
--- a/src/components/common/AppCardLink/index.tsx
+++ b/src/components/common/AppCardLink/index.tsx
@@ -23,7 +23,7 @@ export const AppCardLink: FC<TProps> = ({ height, variant, href }) => {
     const AppCardComponent = appCardMap[variant];
 
     return (
-        <S.Wrapper href={href} target={'_blank'}>
+        <S.Wrapper href={href} target={'_blank'} rel="noopener noreferrer">
             <AppCardComponent height={height} />
         </S.Wrapper>
     );


### PR DESCRIPTION
## Что сделано

Задача 0.6 из волны 0 (SEC-001): единственный `target="_blank"` в кодовой базе открывался без `rel` — вектор reverse tabnabbing (открытая вкладка через `window.opener` может перенаправить исходную на фишинговый двойник).

Однострочная правка в `src/components/common/AppCardLink/index.tsx`. Публичные props не менялись, поведение для легитимного использования не меняется.

## Проверено

lint (0 ошибок), typecheck, test — зелёные.