### PR TITLE
feat(Toast): дедупликация через toastId (задача 2.7)

### DIFF
--- a/src/components/common/Toast/index.tsx
+++ b/src/components/common/Toast/index.tsx
@@ -5,12 +5,23 @@ import { TToastPalette } from './palette';
 import { toast as libToast } from 'react-toastify';
 import { Typography } from '../Typography';
 
+type TToastOptions = {
+    toastId?: string;
+};
+
+// toastId по умолчанию выводится из текста: пока тост с таким id виден,
+// повторные вызовы с тем же сообщением игнорируются react-toastify —
+// одинаковые ошибки не стекаются в «бурю тостов»
 export const toast = {
-    error: (message: string) => {
-        libToast.error(() => <Typography variant="bodyMRegular">{message}</Typography>);
+    error: (message: string, options?: TToastOptions) => {
+        libToast.error(() => <Typography variant="bodyMRegular">{message}</Typography>, {
+            toastId: options?.toastId ?? `error:${message}`,
+        });
     },
-    success: (message: string) => {
-        libToast.success(() => <Typography variant="bodyMRegular">{message}</Typography>);
+    success: (message: string, options?: TToastOptions) => {
+        libToast.success(() => <Typography variant="bodyMRegular">{message}</Typography>, {
+            toastId: options?.toastId ?? `success:${message}`,
+        });
     },
 };
 


### PR DESCRIPTION
## Что сделано

Задача 2.7 из волны 2 (RES-003): обёртка `toast.error`/`toast.success` не имела дедупликации — одинаковая ошибка в цикле у потребителя стекала N одинаковых тостов.

Теперь `toastId` по умолчанию выводится из типа и текста (`error:<текст>` / `success:<текст>`) — это нативный механизм react-toastify: пока тост с таким id виден, повторные вызовы игнорируются. Добавлен опциональный второй аргумент `options.toastId` для собственного ключа дедупликации.

API-совместимость: существующие вызовы `toast.error('...')` работают без изменений (аргумент опциональный), это не breaking change.

## Проверено

- Вживую в Storybook (common/Toast): 5 быстрых кликов «Error» → 1 тост; «Error» + 2×«Success» → 2 тоста (разные типы и тексты не схлопываются между собой).
- lint 0 ошибок, typecheck чисто, тесты зелёные.