### PR TITLE
feat(lint): eslint-plugin-jsx-a11y как error (задача 2.1)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,7 @@
     "parserOptions": {
         "project": "tsconfig.json"
     },
-    "plugins": ["react", "@typescript-eslint", "prettier", "react-hooks", "jest"],
+    "plugins": ["react", "@typescript-eslint", "prettier", "react-hooks", "jest", "jsx-a11y"],
     "extends": [
         "plugin:storybook/recommended",
         "eslint:recommended",
@@ -21,7 +21,8 @@
         "plugin:@typescript-eslint/recommended",
         "prettier",
         "plugin:react-hooks/recommended",
-        "plugin:jest/recommended"
+        "plugin:jest/recommended",
+        "plugin:jsx-a11y/recommended"
     ],
     "rules": {
         "prettier/prettier": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
                 "babel-plugin-styled-components": "^2.1.4",
                 "eslint": "^8.56.0",
                 "eslint-config-prettier": "^9.1.0",
+                "eslint-plugin-jsx-a11y": "^6.10.2",
                 "eslint-plugin-prettier": "^5.1.3",
                 "eslint-plugin-react": "^7.34.1",
                 "eslint-plugin-react-hooks": "^4.6.0",
@@ -10810,8 +10811,7 @@
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
             "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/async": {
             "version": "3.2.6",
@@ -10899,7 +10899,6 @@
             "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.1.tgz",
             "integrity": "sha512-qPC9o+kD8Tir0lzNGLeghbOrWMr3ZJpaRlCIb6Uobt/7N4FiEDvqUMnxzCHRHmg8vOg14kr5gVNyScRmbMaJ9g==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -10909,7 +10908,6 @@
             "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
             "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 0.4"
             }
@@ -13214,8 +13212,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
             "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/data-urls": {
             "version": "2.0.0",
@@ -14606,11 +14603,10 @@
             }
         },
         "node_modules/eslint-plugin-jsx-a11y": {
-            "version": "6.10.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.1.tgz",
-            "integrity": "sha512-zHByM9WTUMnfsDTafGXRiqxp6lFtNoSOWBY6FonVRn3A+BUwN1L/tdBXT40BcBJi0cZjOGTXZ0eD/rTG9fEJ0g==",
+            "version": "6.10.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+            "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "aria-query": "^5.3.2",
                 "array-includes": "^3.1.8",
@@ -14620,7 +14616,6 @@
                 "axobject-query": "^4.1.0",
                 "damerau-levenshtein": "^1.0.8",
                 "emoji-regex": "^9.2.2",
-                "es-iterator-helpers": "^1.1.0",
                 "hasown": "^2.0.2",
                 "jsx-ast-utils": "^3.3.5",
                 "language-tags": "^1.0.9",
@@ -14641,7 +14636,6 @@
             "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
             "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 0.4"
             }
@@ -21502,15 +21496,13 @@
             "version": "0.3.23",
             "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
             "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/language-tags": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
             "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "language-subtag-registry": "^0.3.20"
             },
@@ -28751,7 +28743,6 @@
             "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
             "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.7",
                 "define-properties": "^1.2.1",
@@ -39164,8 +39155,7 @@
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
             "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "async": {
             "version": "3.2.6",
@@ -39220,15 +39210,13 @@
             "version": "4.10.1",
             "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.1.tgz",
             "integrity": "sha512-qPC9o+kD8Tir0lzNGLeghbOrWMr3ZJpaRlCIb6Uobt/7N4FiEDvqUMnxzCHRHmg8vOg14kr5gVNyScRmbMaJ9g==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "axobject-query": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
             "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "babel-core": {
             "version": "7.0.0-bridge.0",
@@ -40936,8 +40924,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
             "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "data-urls": {
             "version": "2.0.0",
@@ -42120,11 +42107,10 @@
             }
         },
         "eslint-plugin-jsx-a11y": {
-            "version": "6.10.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.1.tgz",
-            "integrity": "sha512-zHByM9WTUMnfsDTafGXRiqxp6lFtNoSOWBY6FonVRn3A+BUwN1L/tdBXT40BcBJi0cZjOGTXZ0eD/rTG9fEJ0g==",
+            "version": "6.10.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+            "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "aria-query": "^5.3.2",
                 "array-includes": "^3.1.8",
@@ -42134,7 +42120,6 @@
                 "axobject-query": "^4.1.0",
                 "damerau-levenshtein": "^1.0.8",
                 "emoji-regex": "^9.2.2",
-                "es-iterator-helpers": "^1.1.0",
                 "hasown": "^2.0.2",
                 "jsx-ast-utils": "^3.3.5",
                 "language-tags": "^1.0.9",
@@ -42148,8 +42133,7 @@
                     "version": "5.3.2",
                     "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
                     "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
-                    "dev": true,
-                    "peer": true
+                    "dev": true
                 }
             }
         },
@@ -47118,15 +47102,13 @@
             "version": "0.3.23",
             "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
             "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "language-tags": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
             "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "language-subtag-registry": "^0.3.20"
             }
@@ -52401,7 +52383,6 @@
             "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
             "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "call-bind": "^1.0.7",
                 "define-properties": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "babel-plugin-styled-components": "^2.1.4",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-hooks": "^4.6.0",

--- a/src/components/form/Autocomplete/components/Autocomplete/index.tsx
+++ b/src/components/form/Autocomplete/components/Autocomplete/index.tsx
@@ -269,6 +269,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, TProps>(
                             paddingLeft={inputPaddingLeft}
                             maxLength={inputMaxLength}
                             isOnlyNumbers={isInputOnlyNumbers}
+                            // eslint-disable-next-line jsx-a11y/no-autofocus -- проп прокидывается потребителю, решение об автофокусе за ним
                             autoFocus={autoFocus}
                             readOnly={readOnly}
                             useModernStyles={useModernStyles}

--- a/src/components/form/CodeInput/index.tsx
+++ b/src/components/form/CodeInput/index.tsx
@@ -99,6 +99,7 @@ export const CodeInput: FC<TProps> = ({
                     placeholder="-"
                     $hasError={hasError}
                     disabled={!!disabled}
+                    // eslint-disable-next-line jsx-a11y/no-autofocus -- проп прокидывается потребителю, решение об автофокусе за ним
                     autoFocus={autoFocus}
                     autoComplete={'one-time-code'}
                     type="text"

--- a/src/components/form/PhoneInput/index.tsx
+++ b/src/components/form/PhoneInput/index.tsx
@@ -325,6 +325,7 @@ export const PhoneInput: FC<TProps> = ({
                         // for disable autocomplete
                         autoComplete={'new-password'}
                         inputMode="numeric"
+                        // eslint-disable-next-line jsx-a11y/no-autofocus -- проп прокидывается потребителю, решение об автофокусе за ним
                         autoFocus={autoFocus}
                         {...paddingAndVariantOptions}
                         useModernStyles={useModernStyles}

--- a/src/components/form/SearchInput/index.tsx
+++ b/src/components/form/SearchInput/index.tsx
@@ -94,6 +94,7 @@ export const SearchInput = forwardRef<HTMLInputElement, TProps>(
                     onFocus={handleFocus}
                     onBlur={handleBlur}
                     inFocus={inFocus}
+                    // eslint-disable-next-line jsx-a11y/no-autofocus -- проп прокидывается потребителю, решение об автофокусе за ним
                     autoFocus={autoFocus}
                     name={name}
                     maxLength={maxLength}

--- a/src/components/form/TextInput/index.tsx
+++ b/src/components/form/TextInput/index.tsx
@@ -126,6 +126,7 @@ export const TextInput = React.forwardRef<HTMLInputElement, TProps>(
                         paddingRight={paddingRight}
                         type={type}
                         isOnlyNumbers={isOnlyNumbers}
+                        // eslint-disable-next-line jsx-a11y/no-autofocus -- проп прокидывается потребителю, решение об автофокусе за ним
                         autoFocus={autoFocus}
                         element={element}
                         rows={rows}


### PR DESCRIPTION
## Что сделано

Задача 2.1 из волны 2 (A11Y-005): установлен `eslint-plugin-jsx-a11y`, подключён `plugin:jsx-a11y/recommended` (правила в режиме error). Теперь регрессии доступности — clickable-div, img без alt, некорректные role — валят lint и, соответственно, CI.

## Существующие срабатывания

Единственное правило, которое сработало на текущей кодовой базе, — `jsx-a11y/no-autofocus`, 5 мест (Autocomplete, CodeInput, PhoneInput, SearchInput, TextInput). Во всех пяти это **прокидывание опционального пропа `autoFocus`** потребителю, не захардкоженный автофокус: решение об автофокусе принимает приложение, а убрать проп — breaking change публичного API.

Закрыто точечными `eslint-disable-next-line` с комментарием-обоснованием (по рекомендации самого аудита про задокументированные узкие исключения). Захардкоженный `autoFocus` в новом коде правило продолжит ловить.

## Проверено

- lint — 0 ошибок (6 известных warnings про `any`, задача 3.1)
- typecheck чисто, тесты 2 suites зелёные
- KPI аудита «jsx-a11y установлен, error» — закрыт