### PR TITLE
feat(a11y): миксин prefers-reduced-motion (задача 2.5)

### DIFF
--- a/src/components/common/Arrow/components/StyledSvg/index.ts
+++ b/src/components/common/Arrow/components/StyledSvg/index.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { Svg } from '../Svg';
+import { reducedMotion } from '../../../../../utils/reducedMotion';
 
 export const StyledSvg = styled(Svg)<{
     $isOpen: boolean;
@@ -10,6 +11,7 @@ export const StyledSvg = styled(Svg)<{
 }>`
     transform: rotateZ(${({ $isOpen, $defaultRotate }) => ($isOpen ? $defaultRotate + 180 : $defaultRotate)}deg);
     transition: all 0.2s ease-in-out 0s;
+    ${reducedMotion}
     box-sizing: content-box;
 
     padding: ${({ $padding }) => $padding}px;

--- a/src/components/common/Drawer/styles.ts
+++ b/src/components/common/Drawer/styles.ts
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import { reducedMotion } from '../../../utils/reducedMotion';
 
 export const Root = styled.div`
     position: fixed;
@@ -15,6 +16,7 @@ export const Backdrop = styled.div<{ $bgColor: string; $isVisible: boolean }>`
     background-color: ${({ $bgColor }) => $bgColor};
     opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
     transition: opacity 300ms ease;
+    ${reducedMotion}
 `;
 
 export const Sheet = styled.div<{
@@ -54,6 +56,8 @@ export const Sheet = styled.div<{
             : css`
                   overflow-y: auto;
               `}
+
+    ${reducedMotion}
 `;
 
 // Зона перетаскивания лежит поверх контента (как DragIndicatorWrapper в react-modal-sheet),

--- a/src/components/common/Dropdown/styles.ts
+++ b/src/components/common/Dropdown/styles.ts
@@ -1,5 +1,6 @@
 import styled, { css } from 'styled-components';
 import { TDropdownPalette } from './palette';
+import { reducedMotion } from '../../../utils/reducedMotion';
 
 // Невидимый якорь в потоке: по его родителю (поле-триггер) считаем позицию портал-дропдауна.
 // display:none — не влияет на вёрстку, но parentElement (само поле) доступен для измерений.
@@ -77,4 +78,6 @@ export const Wrapper = styled.div<{
     ${({ $translateY }) => css`
         transform: translateY(${$translateY});
     `};
+
+    ${reducedMotion}
 `;

--- a/src/components/common/SecondaryButton/styles.ts
+++ b/src/components/common/SecondaryButton/styles.ts
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components';
 import { Typography } from '../Typography';
 import { TSecondaryButtonPalette } from './palette';
+import { reducedMotion } from '../../../utils/reducedMotion';
 
 export const Inner = styled(Typography)<{ $isLoading?: boolean }>`
     visibility: ${({ $isLoading }) => ($isLoading ? 'hidden' : 'visible')};
@@ -58,6 +59,8 @@ export const Wrapper = styled.button<{
                 opacity: 0.5;
             }
         `}
+
+    ${reducedMotion}
 `;
 
 export const LoaderWrapper = styled.div`

--- a/src/components/common/Skeleton/styles.ts
+++ b/src/components/common/Skeleton/styles.ts
@@ -1,5 +1,6 @@
 import styled, { keyframes } from 'styled-components';
 import { TSkeletonPalette } from './palette';
+import { reducedMotion } from '../../../utils/reducedMotion';
 
 const shine = keyframes`
     0% {
@@ -31,4 +32,5 @@ export const Inner = styled.div<{ $palette: TSkeletonPalette }>`
         ${({ $palette }) => $palette.bg} 100px
     );
     animation: ${shine} 3s infinite linear;
+    ${reducedMotion}
 `;

--- a/src/components/form/Autocomplete/components/AutocompleteDefaultOption/index.tsx
+++ b/src/components/form/Autocomplete/components/AutocompleteDefaultOption/index.tsx
@@ -2,6 +2,7 @@ import React, { FC, ReactNode } from 'react';
 import styled from 'styled-components';
 import { typography } from '../../../../common/Typography/typography';
 import { Typography } from '../../../../common/Typography';
+import { reducedMotion } from '../../../../../utils/reducedMotion';
 
 export type TProps = {
     children: ReactNode;
@@ -26,4 +27,5 @@ const Wrapper = styled(Typography)<{ $usePadding: boolean }>`
     transition: all 0.2s ease-in-out;
     ${typography.bodyMRegular}
     box-sizing: border-box;
+    ${reducedMotion}
 `;

--- a/src/components/form/Checkbox/styles.ts
+++ b/src/components/form/Checkbox/styles.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { CheckIcon } from './CheckIcon';
 import { TCheckboxPalette } from './palette';
+import { reducedMotion } from '../../../utils/reducedMotion';
 
 const TRANSITION = 'all .2s ease-in-out';
 const BORDER_RADIUS_MIN = 4;
@@ -16,6 +17,7 @@ export const HiddenCheckbox = styled.input`
 
 export const CheckboxIcon = styled(CheckIcon)`
     transition: ${TRANSITION};
+    ${reducedMotion}
 `;
 
 export const StyledCheckbox = styled.div`
@@ -26,6 +28,7 @@ export const StyledCheckbox = styled.div`
     height: 16px;
     border-radius: ${BORDER_RADIUS_MIN}px;
     transition: ${TRANSITION};
+    ${reducedMotion}
 `;
 
 const getStylesCheckbox = (palette: TCheckboxPalette, disabled: boolean, checked: boolean) => {

--- a/src/components/form/DateTimeInput/components/MobileNumbersColumn/styles.ts
+++ b/src/components/form/DateTimeInput/components/MobileNumbersColumn/styles.ts
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import { reducedMotion } from '../../../../../utils/reducedMotion';
 
 export const Wrapper = styled.div`
     height: 100%;
@@ -35,4 +36,5 @@ export const Number = styled.div<{ $opacity: number; $incline: number; $isActive
         css`
             margin: 4px 0;
         `}
+    ${reducedMotion}
 `;

--- a/src/components/form/InputLabel/styles.ts
+++ b/src/components/form/InputLabel/styles.ts
@@ -2,6 +2,7 @@ import styled, { css, keyframes } from 'styled-components';
 import { Typography } from '../../common/Typography';
 import { TInputLabelPalette } from './palette';
 import { LABEL_PADDING } from './constants';
+import { reducedMotion } from '../../../utils/reducedMotion';
 
 const labelFadeIn = keyframes`
     from {
@@ -32,6 +33,7 @@ export const Label = styled(Typography)<{
     transition: color 0.2s ease-in-out 0s;
     animation: ${labelFadeIn} 0.15s ease;
     color: ${({ $inFocus, $palette }) => ($inFocus ? $palette.textHighlight : $palette.text)};
+    ${reducedMotion}
 
     ${({ $required, $palette }) =>
         $required &&

--- a/src/components/form/ModernPlaceholder/styles.ts
+++ b/src/components/form/ModernPlaceholder/styles.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { Typography } from '../../common/Typography';
+import { reducedMotion } from '../../../utils/reducedMotion';
 
 export const Wrapper = styled(Typography)<{
     $visible: boolean;
@@ -26,6 +27,7 @@ export const Wrapper = styled(Typography)<{
         opacity 0.15s ease,
         transform 0.15s ease;
     color: ${({ $color }) => $color};
+    ${reducedMotion}
 `;
 
 export const TextContent = styled.span`

--- a/src/components/form/PureInput/styles.ts
+++ b/src/components/form/PureInput/styles.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { TPureInputPalette } from './palette';
+import { reducedMotion } from '../../../utils/reducedMotion';
 import { InputWithTypography } from '../../common/Typography';
 import { ElementType } from 'react';
 import { typography } from '../../common/Typography/typography';
@@ -75,6 +76,8 @@ export const getPureInputStyled = (component: ElementType) => styled(component)<
             background-color 0s 600000s,
             color 0s 600000s !important;
     }
+
+    ${reducedMotion}
 `;
 
 export const Wrapper = getPureInputStyled(InputWithTypography);

--- a/src/components/form/SearchInput/styles.ts
+++ b/src/components/form/SearchInput/styles.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { TSearchInputPalette } from './palette';
+import { reducedMotion } from '../../../utils/reducedMotion';
 
 export const IconWrapper = styled.span<{
     $inFocus: boolean;
@@ -16,4 +17,5 @@ export const IconWrapper = styled.span<{
     opacity: ${({ $inFocus }) => ($inFocus ? 1 : 0.5)};
     transition: all 0.2s ease-in-out 0s;
     color: ${({ $palette }) => $palette.icon};
+    ${reducedMotion}
 `;

--- a/src/components/form/Select/styles.ts
+++ b/src/components/form/Select/styles.ts
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components';
 import { Typography } from '../../common/Typography';
 import { TSelectPalette } from './palette';
+import { reducedMotion } from '../../../utils/reducedMotion';
 
 export const Wrapper = styled.div`
     position: relative;
@@ -49,6 +50,8 @@ export const Option = styled(Typography)<{
         css`
             padding-left: 30px;
         `}
+
+    ${reducedMotion}
 `;
 
 export const Group = styled(Typography)`

--- a/src/components/form/Toggle/styles.ts
+++ b/src/components/form/Toggle/styles.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { typography } from '../../common/Typography/typography';
 import { TTogglePalette } from './palette';
+import { reducedMotion } from '../../../utils/reducedMotion';
 
 export type TToggleSize = 'small' | 'medium';
 
@@ -100,4 +101,6 @@ export const StyledInput = styled.input<{
             box-shadow: 0 3px 8px rgba(0, 0, 0, 0.15);
         }
     }
+
+    ${reducedMotion}
 `;

--- a/src/utils/reducedMotion.ts
+++ b/src/utils/reducedMotion.ts
@@ -1,0 +1,18 @@
+import { css } from 'styled-components';
+
+// Общий миксин: отключает анимации/переходы для пользователей с системной
+// настройкой reduced motion (WCAG 2.3.3). Добавлять последним в styled-блок,
+// содержащий transition/animation (включая правила в ::before/::after) —
+// поздние декларации побеждают. Глобального стиля здесь быть не может:
+// sideEffects: false.
+export const reducedMotion = css`
+    @media (prefers-reduced-motion: reduce) {
+        &,
+        &::before,
+        &::after,
+        &::placeholder {
+            transition: none;
+            animation: none;
+        }
+    }
+`;


### PR DESCRIPTION
## Что сделано

Задача 2.5 из волны 2 (A11Y-004): в ките не было ни одной защиты `prefers-reduced-motion` — пользователи с вестибулярными нарушениями получали все анимации.

- Общий миксин `reducedMotion` в `src/utils/reducedMotion.ts`: под `@media (prefers-reduced-motion: reduce)` отключает `transition`/`animation` элемента **и его `::before`/`::after`/`::placeholder`** (важно для Toggle — его переход живёт в `&:after`).
- Добавлен последним в каждый styled-блок с transition/keyframes — 14 файлов: Drawer (backdrop + sheet), Dropdown, Select (опции), Checkbox, Toggle, PureInput, InputLabel (fadeIn + color), ModernPlaceholder, SearchInput, опции Autocomplete, Arrow, SecondaryButton, Skeleton (shimmer), MobileNumbersColumn (DateTimeInput).
- Миксин внутренний, в публичный API не экспортируется.

## Осознанные решения

- **Глобального стиля нет** — `sideEffects: false`: инъекция глобального CSS сломала бы tree-shaking у всех потребителей. Только пер-компонентный миксин.
- **Лоадеры не отключаются** (`Select/Loader`, `InvoiceboxSpinner`): движение спиннера — essential-индикация «идёт загрузка» (так же поступают Chakra, Polaris). `PointsLoader` анимирует только цвет — это не motion. Декоративный shimmer `Skeleton` при этом отключается.
- Webkit-autofill-хак в PureInput (`transition ... !important`) сознательно не перекрывается — он не про движение.
- Drawer: таймер размонтирования по `ANIMATION_MS` не менялся — при reduce панель скрывается мгновенно, размонтируется по прежнему таймеру, поведение потребителя не меняется.

## Проверено

- Вживую в Storybook: на стори TextInput в CSSOM присутствуют 6 `@media (prefers-reduced-motion: reduce)`-правил, отрендеренный input покрыт правилом (проверка через `element.matches(selector)`).
- Покрытие полное: grep по `transition:`/`animation:` в src — без миксина остались только 3 файла-исключения (лоадеры).
- lint 0 ошибок, typecheck чисто, тесты зелёные.