### PR TITLE
feat(a11y): ARIA для Tooltip и Dropdown (задача 2.3)

### DIFF
--- a/src/components/common/Dropdown/index.tsx
+++ b/src/components/common/Dropdown/index.tsx
@@ -38,6 +38,9 @@ export type TProps = {
     onCloseTransitionEnd?: () => void;
     isTopPosition?: boolean;
     usePadding?: boolean;
+    // ARIA-роль контейнера поповера: задаётся местом использования
+    // (например, "dialog" для календаря; "listbox" требует ролей на опциях)
+    role?: string;
 };
 
 export const Dropdown = forwardRef<HTMLDivElement, TProps>(
@@ -55,6 +58,7 @@ export const Dropdown = forwardRef<HTMLDivElement, TProps>(
             onCloseTransitionEnd,
             isTopPosition = false,
             usePadding = false,
+            role,
         },
         forwardedRef,
     ) => {
@@ -176,6 +180,7 @@ export const Dropdown = forwardRef<HTMLDivElement, TProps>(
                         >
                             <S.Wrapper
                                 ref={setWrapperRef}
+                                role={role}
                                 $isVisible={isOpen}
                                 $isAbove={position.current.isAbove}
                                 $translateY={position.current.translateY}

--- a/src/components/common/Tooltip/index.tsx
+++ b/src/components/common/Tooltip/index.tsx
@@ -1,4 +1,12 @@
-import React, { PropsWithChildren, ReactNode, useCallback, useRef, useState } from 'react';
+import React, {
+    KeyboardEvent,
+    PropsWithChildren,
+    ReactNode,
+    useCallback,
+    useId,
+    useRef,
+    useState,
+} from 'react';
 import { createPortal } from 'react-dom';
 import { Typography } from '../Typography';
 import { useComponentPalette } from '../../../palette';
@@ -19,6 +27,7 @@ export const Tooltip = ({ overlay, placement = 'top', gap = 8, children }: Props
     const palette = useComponentPalette<TTooltipPalette>('tooltip');
     const triggerRef = useRef<HTMLSpanElement>(null);
     const [coords, setCoords] = useState<TCoords | null>(null);
+    const tooltipId = useId();
 
     const show = useCallback(() => {
         const el = triggerRef.current;
@@ -32,13 +41,31 @@ export const Tooltip = ({ overlay, placement = 'top', gap = 8, children }: Props
 
     const hide = useCallback(() => setCoords(null), []);
 
+    // WAI-ARIA tooltip: Escape закрывает тултип, не убирая фокус с триггера
+    const handleKeyDown = useCallback(
+        (event: KeyboardEvent<HTMLSpanElement>) => {
+            if (event.key === 'Escape') hide();
+        },
+        [hide],
+    );
+
     return (
-        <S.Trigger ref={triggerRef} onMouseEnter={show} onMouseLeave={hide} onFocus={show} onBlur={hide}>
+        <S.Trigger
+            ref={triggerRef}
+            onMouseEnter={show}
+            onMouseLeave={hide}
+            onFocus={show}
+            onBlur={hide}
+            onKeyDown={handleKeyDown}
+            aria-describedby={coords ? tooltipId : undefined}
+        >
             {children}
 
             {coords &&
                 createPortal(
                     <S.Overlay
+                        id={tooltipId}
+                        role="tooltip"
                         $palette={palette}
                         $top={coords.top}
                         $left={coords.left}

--- a/src/components/form/DateInput/index.tsx
+++ b/src/components/form/DateInput/index.tsx
@@ -172,7 +172,7 @@ export const DateInput: FC<TProps> = ({
                     maxDate={maxDate}
                 />
             ) : (
-                <Dropdown ref={dropdownRef} isOpen={isOpen} isAutoPosition {...dropdownProps}>
+                <Dropdown ref={dropdownRef} isOpen={isOpen} isAutoPosition role="dialog" {...dropdownProps}>
                     <S.CalendarWrapper>
                         <Calendar
                             value={value}

--- a/src/components/form/DateTimeInput/index.tsx
+++ b/src/components/form/DateTimeInput/index.tsx
@@ -215,7 +215,7 @@ export const DateTimeInput: FC<TProps> = ({
                 </S.InputWrapper>
             </InputLabel>
             {!isMobile ? (
-                <Dropdown ref={dropdownRef} isOpen={isOpen} isAutoPosition {...dropdownProps}>
+                <Dropdown ref={dropdownRef} isOpen={isOpen} isAutoPosition role="dialog" {...dropdownProps}>
                     <S.CalendarWithTimePicker $dividerColor={palette.divider}>
                         <S.CalendarWrapper ref={calendarRef} $dividerColor={palette.divider}>
                             <Calendar


### PR DESCRIPTION
## Что сделано

Задача 2.3 из волны 2 (A11Y-003).

**Tooltip** — полный WAI-ARIA tooltip-паттерн:
- оверлей: `role="tooltip"` + `id` (через `useId`, как в Autocomplete);
- триггер: `aria-describedby` на id оверлея, пока тултип виден — скринридер зачитывает подсказку при фокусе (показ по focus/blur уже был реализован);
- `Escape` закрывает тултип, фокус остаётся на триггере (требование паттерна).

**Dropdown**:
- новый опциональный проп `role`, прокидывается на контейнер поповера — роль определяется контекстом использования;
- календарные поповеры `DateInput`/`DateTimeInput` объявлены `role="dialog"` (проп стоит до `{...dropdownProps}`, потребитель может переопределить).

**Сознательно не сделано здесь:** `role="listbox"` для дропдауна `Select` — без `role="option"` на пунктах listbox невалиден и только ухудшит озвучку; это цельный кусок задачи 2.4 (ARIA на Select по паттерну Autocomplete).

API: только добавление опционального пропа, breaking changes нет.

## Проверено вживую (Storybook)

- Tooltip: наведение → оверлей с `role="tooltip"`, `aria-describedby` триггера == id оверлея; Escape → тултип закрыт, атрибут снят.
- DateInput: клик по полю → поповер календаря с `role="dialog"` и календарём внутри.
- lint 0 ошибок (jsx-a11y включён — доволен), typecheck чисто, тесты зелёные.