### PR TITLE
feat(a11y): ARIA и клавиатура для Checkbox, Toggle, Select (задача 2.4)

### DIFF
--- a/src/components/form/Checkbox/styles.ts
+++ b/src/components/form/Checkbox/styles.ts
@@ -11,8 +11,18 @@ export const CheckboxContainer = styled.div`
     vertical-align: middle;
 `;
 
+// Инпут скрыт визуально, но остаётся в дереве доступности и фокусируем с
+// клавиатуры (display: none выключал и то и другое) — паттерн visually hidden
 export const HiddenCheckbox = styled.input`
-    display: none;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
 `;
 
 export const CheckboxIcon = styled(CheckIcon)`
@@ -82,5 +92,10 @@ export const CheckboxLabel = styled.label<{
         ${StyledCheckbox} {
             ${({ $checked, $disabled, $palette }) => getHoverStylesCheckbox($palette, $disabled, $checked)};
         }
+    }
+
+    ${HiddenCheckbox}:focus-visible + ${StyledCheckbox} {
+        outline: 2px solid ${({ $palette }) => $palette.borderHover};
+        outline-offset: 2px;
     }
 `;

--- a/src/components/form/Select/components/Input/index.tsx
+++ b/src/components/form/Select/components/Input/index.tsx
@@ -17,6 +17,16 @@ export type TProps = Pick<TInputLabelProps, 'inFocus' | 'label' | 'required'> &
         size?: TSizes;
         renderedValue?: React.ReactNode;
         useModernStyles?: boolean;
+        // ARIA-атрибуты и клавиатура комбобокса — прокидываются на PureInput как есть
+        comboboxProps?: Pick<
+            TPureInputProps,
+            | 'role'
+            | 'aria-expanded'
+            | 'aria-haspopup'
+            | 'aria-controls'
+            | 'aria-activedescendant'
+            | 'onKeyDown'
+        >;
     };
 
 export const Input = forwardRef<HTMLInputElement, TProps>(
@@ -38,6 +48,7 @@ export const Input = forwardRef<HTMLInputElement, TProps>(
             required,
             useModernStyles = false,
             id,
+            comboboxProps,
         },
         ref,
     ) => {
@@ -84,6 +95,10 @@ export const Input = forwardRef<HTMLInputElement, TProps>(
                         paddingRight={52}
                         onClick={onClick}
                         useModernStyles={useModernStyles}
+                        // с renderedValue PureInput рендерится как div — без tabIndex
+                        // он был бы недостижим с клавиатуры
+                        tabIndex={renderedValue ? 0 : undefined}
+                        {...comboboxProps}
                         {...paddingAndVariantOptions}
                     />
 

--- a/src/components/form/Select/index.tsx
+++ b/src/components/form/Select/index.tsx
@@ -1,9 +1,12 @@
 import React, {
     FocusEvent,
     Fragment,
+    KeyboardEvent,
     MouseEvent,
     ReactNode,
     useCallback,
+    useEffect,
+    useId,
     useMemo,
     useRef,
     useState,
@@ -146,8 +149,35 @@ export const Select = <TValue extends string | number>(props: TAllProps<TValue>)
 
     const optionGroups = useOptionGroups(options, groups);
 
-    const handleShow = useCallback(() => setIsOpen(true), []);
+    // Плоский список опций в порядке отрисовки (группы разворачиваются) —
+    // по нему ходит клавиатурная навигация и считаются id для activedescendant
+    const flatOptions = useMemo(
+        () => optionGroups.reduce<TOption<TValue>[]>((acc, group) => acc.concat(group.options), []),
+        [optionGroups],
+    );
+    const optionIndexByValue = useMemo(
+        () => new Map<TValue, number>(flatOptions.map((option, index) => [option.value, index])),
+        [flatOptions],
+    );
+
+    const baseId = useId();
+    const listboxId = `${baseId}-listbox`;
+    const getOptionId = (index: number) => `${baseId}-option-${index}`;
+
+    // Позиция клавиатурного фокуса в списке (aria-activedescendant)
+    const [activeIndex, setActiveIndex] = useState(-1);
+
+    const handleShow = useCallback(() => {
+        setIsOpen(true);
+        // при открытии встаём на выбранную опцию (single), иначе — вне списка
+        setActiveIndex(isMultiple ? -1 : flatOptions.findIndex((option) => option.value === value));
+    }, [flatOptions, isMultiple, value]);
     const handleHide = useCallback(() => setIsOpen(false), []);
+
+    useEffect(() => {
+        if (activeIndex < 0) return;
+        document.getElementById(`${baseId}-option-${activeIndex}`)?.scrollIntoView({ block: 'nearest' });
+    }, [activeIndex, baseId]);
 
     const dropdownRef = useRef<HTMLDivElement>(null);
     const wrapperRef = useOutsideClick(handleHide, [dropdownRef]);
@@ -175,10 +205,8 @@ export const Select = <TValue extends string | number>(props: TAllProps<TValue>)
         [blurHandler],
     );
 
-    const handleSelect = useCallback(
-        (event: MouseEvent<HTMLDivElement>) => {
-            const newValue = JSON.parse(event.currentTarget.dataset.value as string) as TValue;
-
+    const selectValue = useCallback(
+        (newValue: TValue) => {
             if (isMultiple) {
                 const next = multipleValue.includes(newValue)
                     ? multipleValue.filter((item) => item !== newValue)
@@ -196,6 +224,50 @@ export const Select = <TValue extends string | number>(props: TAllProps<TValue>)
             }
         },
         [handleHide, isMultiple, multipleValue, onChangeMultiple, onChangeSingle],
+    );
+
+    const handleSelect = useCallback(
+        (event: MouseEvent<HTMLDivElement>) => {
+            selectValue(JSON.parse(event.currentTarget.dataset.value as string) as TValue);
+        },
+        [selectValue],
+    );
+
+    // Клавиатурная навигация комбобокса — тот же набор клавиш, что в Autocomplete
+    const handleKeyDown = useCallback(
+        (event: KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+            const count = flatOptions.length;
+            switch (event.key) {
+                case 'ArrowDown':
+                    event.preventDefault();
+                    if (!isOpen) handleShow();
+                    else if (count) setActiveIndex((prev) => (prev + 1) % count);
+                    break;
+                case 'ArrowUp':
+                    event.preventDefault();
+                    if (!isOpen) handleShow();
+                    else if (count) setActiveIndex((prev) => (prev <= 0 ? count - 1 : prev - 1));
+                    break;
+                case 'Enter':
+                case ' ':
+                    event.preventDefault();
+                    if (!isOpen) {
+                        handleShow();
+                    } else if (activeIndex >= 0 && activeIndex < count) {
+                        selectValue(flatOptions[activeIndex].value);
+                    }
+                    break;
+                case 'Escape':
+                    if (isOpen) {
+                        event.preventDefault();
+                        handleHide();
+                    }
+                    break;
+                default:
+                    break;
+            }
+        },
+        [activeIndex, flatOptions, handleHide, handleShow, isOpen, selectValue],
     );
 
     const handleRemoveTag = useCallback(
@@ -250,41 +322,53 @@ export const Select = <TValue extends string | number>(props: TAllProps<TValue>)
     };
 
     const scrollbarContent = (
-        <S.ScrollbarContent>
+        <S.ScrollbarContent role="listbox" id={listboxId} aria-multiselectable={isMultiple || undefined}>
             {scrollbarHeader}
 
             {optionGroups.map(({ group, options: groupOptions }) => (
                 <Fragment key={group?.id || null}>
                     {handleGroupRender(group)}
-                    {groupOptions.map((option) => (
-                        <S.OptionWrapper $usePadding={usePadding} key={option.value}>
-                            <S.Option
-                                key={option.value}
-                                $palette={palette}
-                                variant="bodyMRegular"
-                                onClick={handleSelect}
-                                data-value={JSON.stringify(option.value)}
-                                data-option-identifier={OPTION_IDENTIFIER}
-                                $isGrouped={!!group && !renderOption}
-                                $usePadding={usePadding}
-                                $isSelected={!isMultiple && option.value === value}
-                            >
-                                {isMultiple ? (
-                                    <S.OptionContent>
-                                        <S.CheckboxWrapper>
-                                            <Checkbox
-                                                checked={selectedValuesSet.has(option.value)}
-                                                readOnly
-                                            />
-                                        </S.CheckboxWrapper>
-                                        {handleOptionRender(option)}
-                                    </S.OptionContent>
-                                ) : (
-                                    handleOptionRender(option)
-                                )}
-                            </S.Option>
-                        </S.OptionWrapper>
-                    ))}
+                    {groupOptions.map((option) => {
+                        const flatIndex = optionIndexByValue.get(option.value) as number;
+                        const isSelected = isMultiple
+                            ? selectedValuesSet.has(option.value)
+                            : option.value === value;
+                        return (
+                            <S.OptionWrapper $usePadding={usePadding} key={option.value}>
+                                <S.Option
+                                    key={option.value}
+                                    id={getOptionId(flatIndex)}
+                                    role="option"
+                                    aria-selected={isSelected}
+                                    $palette={palette}
+                                    variant="bodyMRegular"
+                                    onClick={handleSelect}
+                                    data-value={JSON.stringify(option.value)}
+                                    data-option-identifier={OPTION_IDENTIFIER}
+                                    $isGrouped={!!group && !renderOption}
+                                    $usePadding={usePadding}
+                                    $isSelected={!isMultiple && option.value === value}
+                                    $isActive={flatIndex === activeIndex}
+                                >
+                                    {isMultiple ? (
+                                        <S.OptionContent>
+                                            <S.CheckboxWrapper>
+                                                <Checkbox
+                                                    checked={selectedValuesSet.has(option.value)}
+                                                    readOnly
+                                                    tabIndex={-1}
+                                                    aria-hidden
+                                                />
+                                            </S.CheckboxWrapper>
+                                            {handleOptionRender(option)}
+                                        </S.OptionContent>
+                                    ) : (
+                                        handleOptionRender(option)
+                                    )}
+                                </S.Option>
+                            </S.OptionWrapper>
+                        );
+                    })}
                 </Fragment>
             ))}
         </S.ScrollbarContent>
@@ -398,6 +482,15 @@ export const Select = <TValue extends string | number>(props: TAllProps<TValue>)
                     onClick={isDrawerOptions || !!renderedValue ? handleInputClick : undefined}
                     required={required}
                     useModernStyles={useModernStyles}
+                    comboboxProps={{
+                        role: 'combobox',
+                        'aria-expanded': isOpen,
+                        'aria-haspopup': 'listbox',
+                        'aria-controls': isOpen && optionGroups.length ? listboxId : undefined,
+                        'aria-activedescendant':
+                            isOpen && activeIndex >= 0 ? getOptionId(activeIndex) : undefined,
+                        onKeyDown: isDrawerOptions ? undefined : handleKeyDown,
+                    }}
                 />
             </S.InputWrapper>
 

--- a/src/components/form/Select/styles.ts
+++ b/src/components/form/Select/styles.ts
@@ -25,6 +25,7 @@ export const Option = styled(Typography)<{
     $isGrouped: boolean;
     $usePadding: boolean;
     $isSelected?: boolean;
+    $isActive?: boolean;
 }>`
     overflow: hidden;
     width: 100%;
@@ -39,6 +40,12 @@ export const Option = styled(Typography)<{
         css`
             background-color: ${$palette.bgHover};
             border-radius: 8px;
+        `}
+
+    ${({ $isActive, $palette }) =>
+        $isActive &&
+        css`
+            background-color: ${$palette.bgHover};
         `}
 
     &:hover {

--- a/src/components/form/Toggle/index.tsx
+++ b/src/components/form/Toggle/index.tsx
@@ -38,6 +38,7 @@ export const Toggle: FC<TProps> = ({
                 checked={checked}
                 onChange={handleChange}
                 type="checkbox"
+                role="switch"
                 disabled={disabled}
                 {...other}
             />

--- a/src/components/form/Toggle/styles.ts
+++ b/src/components/form/Toggle/styles.ts
@@ -102,5 +102,10 @@ export const StyledInput = styled.input<{
         }
     }
 
+    &:focus-visible {
+        outline: 2px solid ${({ $palette }) => $palette.activeBg};
+        outline-offset: 2px;
+    }
+
     ${reducedMotion}
 `;


### PR DESCRIPTION
## Что сделано

Задача 2.4 из волны 2 (A11Y-001) — самая крупная задача волны: ARIA на три формовых компонента по образцу эталонного `Autocomplete`.

### Checkbox
Скрытый инпут был `display: none` — **невидим для скринридеров и недостижим с клавиатуры вовсе**. Заменён на visually-hidden-паттерн: нативный чекбокс остаётся в дереве доступности (role/state бесплатно от браузера), фокусируется, Space переключает. Фокус показывается outline'ом на визуальном квадрате (`:focus-visible + селектор соседа`).

### Toggle
`role="switch"` — скринридер озвучивает как переключатель, состояние берётся из нативного `checked`. Добавлен outline при `:focus-visible` (инпут и раньше был фокусируем, но фокус не был виден).

### Select — полный комбобокс-паттерн
- Инпут: `role="combobox"`, `aria-expanded`, `aria-haspopup="listbox"`, `aria-controls`, `aria-activedescendant` (id — `useId`, как в Autocomplete).
- Список: `role="listbox"` + `aria-multiselectable` для multiple; опции: `role="option"`, `aria-selected`, стабильные id.
- **Клавиатурная навигация с нуля** (её не было совсем): ArrowDown/ArrowUp открывают и ходят по списку (группы разворачиваются в плоский список), Enter/Space выбирают (multiple не закрывает список), Escape закрывает. Активная опция подсвечивается и докручивается `scrollIntoView({ block: 'nearest' })`.
- Починен связанный разрыв: с `renderedValue` (multiple-чипы или `renderValue`) поле рендерится как div и **было недостижимо с клавиатуры** — добавлен `tabIndex={0}`.
- Декоративный чекбокс в multiple-опциях получил `tabIndex={-1}` + `aria-hidden` — состояние выбора несёт `aria-selected` опции, лишние фокус-стопы внутри listbox не нужны.

## API

Публичные props не менялись. `comboboxProps` — новый проп внутреннего компонента `Select/components/Input` (не экспортируется из пакета). Refactor `handleSelect` → `selectValue` — внутренний, поведение мыши идентично.

## Проверено вживую (Storybook)

- Select: ArrowDown → `aria-expanded=true`, `aria-controls` совпадает с id listbox; стрелки двигают `aria-activedescendant`; Enter выбирает опцию (значение в инпуте) и закрывает; Escape закрывает.
- Checkbox: инпут визуально скрыт, но `display !== none`, фокусируется, клик даёт change.
- Toggle: `role="switch"`, фокусируется.
- lint (jsx-a11y) 0 ошибок, typecheck чисто, тесты зелёные, build собирается.

## Что осознанно не здесь

Скринридер-проход (VoiceOver) из критерия выхода волны 2 — ручная проверка после merge всех задач волны; фокус-трап Drawer — задача 2.2.