### PR TITLE
feat(resilience): error boundary для Select/Autocomplete/Drawer (задача 2.8)

### DIFF
--- a/src/components/common/Drawer/index.tsx
+++ b/src/components/common/Drawer/index.tsx
@@ -14,6 +14,7 @@ import { Typography } from '../Typography';
 import { useComponentPalette } from '../../../palette';
 import { useLockBodyScroll } from '../../../hooks/useLockBodyScroll';
 import { TDrawerPalette } from './palette';
+import { ErrorBoundary } from '../ErrorBoundary';
 
 export type TProps = {
     children: ReactNode;
@@ -132,7 +133,9 @@ export const Drawer: FC<TProps> = ({
                 )}
 
                 <S.ChildrenWrapper $bgColor={palette.bg} $isPadding={isPadding}>
-                    {children}
+                    {/* Падение пользовательского контента не роняет страницу: шторка
+                        остаётся управляемой (закрытие работает), контент — пустой (RES-001) */}
+                    <ErrorBoundary>{children}</ErrorBoundary>
                 </S.ChildrenWrapper>
             </S.Sheet>
         </S.Root>,

--- a/src/components/common/ErrorBoundary/index.tsx
+++ b/src/components/common/ErrorBoundary/index.tsx
@@ -1,0 +1,34 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+
+type TProps = {
+    // что показать вместо упавшего поддерева; по умолчанию — ничего
+    fallback?: ReactNode;
+    children: ReactNode;
+};
+
+type TState = { hasError: boolean };
+
+// Локальная граница ошибок: исключение в пользовательском render-контенте
+// (renderOption/renderValue/children) ломает один виджет, а не всё
+// React-дерево приложения-потребителя. Класс — единственный способ
+// реализовать границу ошибок в React 18.
+// Не экспортируется из пакета: внутренняя страховка, а не публичный API.
+export class ErrorBoundary extends Component<TProps, TState> {
+    state: TState = { hasError: false };
+
+    static getDerivedStateFromError(): TState {
+        return { hasError: true };
+    }
+
+    componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+        // Библиотека намеренно не навязывает трекер ошибок;
+        // опциональный onError-контракт — задача 3.7 аудита
+        // eslint-disable-next-line no-console
+        console.error('[@invoicebox/ui] render error:', error, errorInfo.componentStack);
+    }
+
+    render() {
+        if (this.state.hasError) return this.props.fallback ?? null;
+        return this.props.children;
+    }
+}

--- a/src/components/form/Autocomplete/components/Autocomplete/index.tsx
+++ b/src/components/form/Autocomplete/components/Autocomplete/index.tsx
@@ -18,6 +18,7 @@ import { Skeleton } from '../../../../common/Skeleton';
 import { useMobile } from '../../../../../hooks/useMedia';
 import { useInputFocus } from '../../../../../hooks/useInputFocus';
 import { useOutsideClick } from '../../../../../hooks/useOutsideClick';
+import { ErrorBoundary } from '../../../../common/ErrorBoundary';
 import { InputLabel } from '../../../InputLabel';
 import { PureInput } from '../../../PureInput';
 import { Dropdown } from '../../../../common/Dropdown';
@@ -78,7 +79,7 @@ type TControlProps = {
 
 export type TProps = TFieldProps & TControlProps;
 
-export const Autocomplete = forwardRef<HTMLInputElement, TProps>(
+const AutocompleteInner = forwardRef<HTMLInputElement, TProps>(
     (
         {
             options,
@@ -348,5 +349,16 @@ export const Autocomplete = forwardRef<HTMLInputElement, TProps>(
         );
     },
 );
+
+AutocompleteInner.displayName = 'AutocompleteInner';
+
+// Граница ошибок снаружи: renderOption/optionsLoader потребителя вызываются в
+// рендере AutocompleteInner — исключение колбэка иначе валило бы всё дерево
+// приложения (RES-001). Fallback — null: поле исчезает, страница живёт.
+export const Autocomplete = forwardRef<HTMLInputElement, TProps>((props, ref) => (
+    <ErrorBoundary>
+        <AutocompleteInner {...props} ref={ref} />
+    </ErrorBoundary>
+));
 
 Autocomplete.displayName = 'Autocomplete';

--- a/src/components/form/Select/index.tsx
+++ b/src/components/form/Select/index.tsx
@@ -25,6 +25,7 @@ import Loader from './components/Loader';
 import { MultipleValue } from './components/MultipleValue';
 import { Checkbox } from '../Checkbox';
 import { TProps as TChipProps } from '../../common/Chip';
+import { ErrorBoundary } from '../../common/ErrorBoundary';
 
 const MAX_LIST_HEIGHT = 294;
 const OPTION_IDENTIFIER = 'option-identifier';
@@ -70,7 +71,7 @@ export type TMultipleProps<TValue> = TSharedProps<TValue> & {
 
 type TAllProps<TValue> = TProps<TValue> | TMultipleProps<TValue>;
 
-export const Select = <TValue extends string | number>(props: TAllProps<TValue>) => {
+const SelectInner = <TValue extends string | number>(props: TAllProps<TValue>) => {
     const {
         label,
         hasError,
@@ -513,3 +514,12 @@ export const Select = <TValue extends string | number>(props: TAllProps<TValue>)
         </S.Wrapper>
     );
 };
+
+// Граница ошибок снаружи: renderOption/renderGroup/renderValue вызываются в
+// рендере SelectInner, и исключение потребительского колбэка иначе валило бы
+// всё дерево приложения (RES-001). Fallback — null: поле исчезает, страница живёт.
+export const Select = <TValue extends string | number>(props: TAllProps<TValue>) => (
+    <ErrorBoundary>
+        <SelectInner {...props} />
+    </ErrorBoundary>
+);


### PR DESCRIPTION
## Что сделано

Задача 2.8 из волны 2 (RES-001): в библиотеке не было ни одной границы ошибок — исключение в потребительском `renderOption`/`renderGroup`/`renderValue`/`children` размонтировало всё React-дерево приложения.

- Внутренний `ErrorBoundary` (`src/components/common/ErrorBoundary/`) — класс-компонент, **не экспортируется из пакета**: это страховка, а не публичный API.
- **Select, Autocomplete** — граница снаружи компонента: их render-колбэки вызываются в рендере самого компонента, внутренняя граница их бы не поймала. Fallback `null` — поле исчезает, страница потребителя живёт.
- **Drawer** — граница внутри, вокруг `children`: хром шторки (заголовок, drag-handle, закрытие) остаётся рабочим, падает только пользовательский контент.
- Ошибка попадает в `console.error` с component stack. Опциональный `onError`-колбэк для потребителя — задача 3.7 (трекеров в UI-ките нет намеренно, см. CLAUDE.md).

## API

Публичные props и экспорты не менялись. `Select`/`Autocomplete` обёрнуты с сохранением сигнатур (generic и forwardRef соответственно).

## Проверено вживую (Storybook, временная стори, удалена до коммита)

- `Select` с `renderOption`, бросающим исключение: соседние элементы страницы живы, поле тихо исчезло, экран ошибки Storybook не показан.
- `Drawer` с бросающим ребёнком: шторка отрисована с заголовком и управляема, страница жива.
- lint 0 ошибок, typecheck чисто, тесты зелёные.

## Ограничение

Граница не «отживает» сама: после исключения компонент остаётся в fallback-состоянии до перемонтирования потребителем. Для страховки от кривого колбэка этого достаточно; сброс по ключу можно добавить, если появится реальный кейс.